### PR TITLE
feat: Solr XML Indexer

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="phpstan" version="^1.10.22" location="./tools/phpstan" copy="false" installed="1.10.22"/>
-  <phar name="composer-normalize" version="^2.32.0" location="./tools/composer-normalize" copy="false" installed="2.32.0"/>
-  <phar name="phpunit" version="^10.4.0" location="./tools/phpunit.phar" copy="true" installed="10.4.1"/>
-  <phar name="overtrue/phplint" version="^9.0.4" location="./tools/phplint" copy="false" installed="9.0.4"/>
-  <phar name="php-cs-fixer" version="^3.58.1" installed="3.58.1" copy="false" location="./tools/php-cs-fixer"/>
+  <phar name="phpstan" version="^1.10.22" location="./tools/phpstan" copy="false" installed="1.11.7"/>
+  <phar name="composer-normalize" version="^2.32.0" location="./tools/composer-normalize" copy="false" installed="2.43.0"/>
+  <phar name="phpunit" version="^10.4.0" location="./tools/phpunit.phar" copy="true" installed="10.5.26"/>
+  <phar name="overtrue/phplint" version="^9.0.4" location="./tools/phplint" copy="false" installed="9.4.1"/>
+  <phar name="php-cs-fixer" version="^3.58.1" installed="3.59.3" copy="false" location="./tools/php-cs-fixer"/>
 </phive>

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "require": {
         "php": ">=8.1 <8.4.0",
         "ext-intl": "*",
+        "ext-xmlreader": "*",
         "atoolo/resource-bundle": "^1.0",
         "dragonmantank/cron-expression": "^3.3",
         "solarium/solarium": "^6.3",
@@ -25,7 +26,7 @@
         "symfony/lock": "^6.3 || ^7.0",
         "symfony/messenger": "^6.3 || ^7.0",
         "symfony/property-access": "^6.3 || ^7.0",
-        "symfony/scheduler": "^6.3 || ^7.1",
+        "symfony/scheduler": "^6.3 || ^7.0",
         "symfony/serializer": "^6.3 || ^7.0",
         "symfony/yaml": "^6.3 || ^7.0"
     },
@@ -75,7 +76,7 @@
             "@analyse:compatibilitycheck"
         ],
         "analyse:compatibilitycheck": "./vendor/bin/phpcs --standard=./phpcs.compatibilitycheck.xml",
-	"analyse:phpcsfixer": "./tools/php-cs-fixer check --diff --show-progress=dots",
+        "analyse:phpcsfixer": "./tools/php-cs-fixer check --diff --show-progress=dots",
         "analyse:phplint": "./tools/phplint",
         "analyse:phpstan": "./tools/phpstan analyse",
         "cs-fix": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5e53c48aee591a522149ebac7c85a3aa",
+    "content-hash": "97ab8d902470c9bceac0ac0e477fd852",
     "packages": [
         {
             "name": "atoolo/resource-bundle",
@@ -3744,20 +3744,20 @@
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "v5.2.13",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jsonrainbow/json-schema.git",
-                "reference": "fbbe7e5d79f618997bc3332a6f49246036c45793"
+                "reference": "feb2ca6dd1cebdaf1ed60a4c8de2e53ce11c4fd8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/fbbe7e5d79f618997bc3332a6f49246036c45793",
-                "reference": "fbbe7e5d79f618997bc3332a6f49246036c45793",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/feb2ca6dd1cebdaf1ed60a4c8de2e53ce11c4fd8",
+                "reference": "feb2ca6dd1cebdaf1ed60a4c8de2e53ce11c4fd8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "~2.2.20||~2.15.1",
@@ -3768,11 +3768,6 @@
                 "bin/validate-json"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "JsonSchema\\": "src/JsonSchema/"
@@ -3808,9 +3803,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jsonrainbow/json-schema/issues",
-                "source": "https://github.com/jsonrainbow/json-schema/tree/v5.2.13"
+                "source": "https://github.com/jsonrainbow/json-schema/tree/5.3.0"
             },
-            "time": "2023-09-26T02:20:38+00:00"
+            "time": "2024-07-06T21:00:26+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -4509,16 +4504,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.24",
+            "version": "10.5.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "5f124e3e3e561006047b532fd0431bf5bb6b9015"
+                "reference": "42e2f13ceaa2e34461bc89bea75407550b40b2aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5f124e3e3e561006047b532fd0431bf5bb6b9015",
-                "reference": "5f124e3e3e561006047b532fd0431bf5bb6b9015",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/42e2f13ceaa2e34461bc89bea75407550b40b2aa",
+                "reference": "42e2f13ceaa2e34461bc89bea75407550b40b2aa",
                 "shasum": ""
             },
             "require": {
@@ -4590,7 +4585,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.24"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.26"
             },
             "funding": [
                 {
@@ -4606,7 +4601,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-20T13:09:54+00:00"
+            "time": "2024-07-08T05:30:46+00:00"
         },
         {
             "name": "roave/security-advisories",
@@ -4614,12 +4609,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "27714b56f04815b654c3805502ab77207505ac19"
+                "reference": "4a150f693df8f5d7b60a8557b15660a60b4d17bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/27714b56f04815b654c3805502ab77207505ac19",
-                "reference": "27714b56f04815b654c3805502ab77207505ac19",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/4a150f693df8f5d7b60a8557b15660a60b4d17bd",
+                "reference": "4a150f693df8f5d7b60a8557b15660a60b4d17bd",
                 "shasum": ""
             },
             "conflict": {
@@ -4627,7 +4622,10 @@
                 "admidio/admidio": "<4.2.13",
                 "adodb/adodb-php": "<=5.20.20|>=5.21,<=5.21.3",
                 "aheinze/cockpit": "<2.2",
+                "aimeos/ai-admin-graphql": ">=2022.04.1,<2022.10.10|>=2023.04.1,<2023.10.6|>=2024.04.1,<2024.04.6",
+                "aimeos/ai-admin-jsonadm": "<2020.10.13|>=2021.04.1,<2021.10.6|>=2022.04.1,<2022.10.3|>=2023.04.1,<2023.10.4|==2024.04.1",
                 "aimeos/ai-client-html": ">=2020.04.1,<2020.10.27|>=2021.04.1,<2021.10.22|>=2022.04.1,<2022.10.13|>=2023.04.1,<2023.10.15|>=2024.04.1,<2024.04.7",
+                "aimeos/ai-controller-frontend": "<2020.10.15|>=2021.04.1,<2021.10.8|>=2022.04.1,<2022.10.8|>=2023.04.1,<2023.10.9",
                 "aimeos/aimeos-core": ">=2022.04.1,<2022.10.17|>=2023.04.1,<2023.10.17|>=2024.04.1,<2024.04.7",
                 "aimeos/aimeos-typo3": "<19.10.12|>=20,<20.10.5",
                 "airesvsg/acf-to-rest-api": "<=3.1",
@@ -5411,7 +5409,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-26T15:05:17+00:00"
+            "time": "2024-07-05T21:04:37+00:00"
         },
         {
             "name": "sanmai/later",
@@ -6798,7 +6796,8 @@
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.1 <8.4.0",
-        "ext-intl": "*"
+        "ext-intl": "*",
+        "ext-xmlreader": "*"
     },
     "platform-dev": [],
     "plugin-api-version": "2.6.0"

--- a/config/indexer.yaml
+++ b/config/indexer.yaml
@@ -113,3 +113,8 @@ services:
     arguments:
       - '%atoolo_search.indexer.internal_resource_indexer_scheduler.cron%'
       - '@atoolo_search.indexer.internal_resource_indexer'
+
+  atoolo_search.indexer.solr_xml_reader:
+    class: Atoolo\Search\Service\Indexer\SolrXmlReader
+    arguments:
+      - '@atoolo_resource.resource_channel'

--- a/src/Dto/Indexer/SolrXmlIndexerEvent.php
+++ b/src/Dto/Indexer/SolrXmlIndexerEvent.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Search\Dto\Indexer;
+
+/**
+ * @codeCoverageIgnore
+ */
+class SolrXmlIndexerEvent {}

--- a/src/Dto/Indexer/SolrXmlIndexerParameter.php
+++ b/src/Dto/Indexer/SolrXmlIndexerParameter.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Search\Dto\Indexer;
+
+/**
+ * @codeCoverageIgnore
+ */
+class SolrXmlIndexerParameter
+{
+    /**
+     * @param array<string> $xmlFileList
+     */
+    public function __construct(
+        public readonly string $source,
+        public readonly int $cleanupThreshold,
+        public readonly int $chunkSize,
+        public readonly array $xmlFileList,
+    ) {}
+}

--- a/src/Service/Indexer/IndexSchema2xDocument.php
+++ b/src/Service/Indexer/IndexSchema2xDocument.php
@@ -177,6 +177,7 @@ class IndexSchema2xDocument extends Document implements IndexDocument
     public function getFields(): array
     {
         return [
+            ...parent::getFields(),
             ...array_filter(
                 get_object_vars($this),
                 fn($value, $key) => !is_null($value)

--- a/src/Service/Indexer/SolrXmlIndexer.php
+++ b/src/Service/Indexer/SolrXmlIndexer.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Search\Service\Indexer;
+
+use Atoolo\Resource\ResourceLanguage;
+use Atoolo\Search\Dto\Indexer\IndexerStatus;
+use Atoolo\Search\Dto\Indexer\SolrXmlIndexerParameter;
+use Atoolo\Search\Service\AbstractIndexer;
+use Atoolo\Search\Service\IndexName;
+use Exception;
+
+/**
+ * This indexer can be used to read XML data in Solr format and
+ * transfer it to the Solr index.
+ * This indexer initially serves as an interim solution to integrate
+ * the existing solutions that generate an XML file in this way.
+ * In the future, these old solutions will implement their own indexer.
+ * Once this has been done, this indexer will no longer be required.
+ */
+class SolrXmlIndexer extends AbstractIndexer
+{
+    public function __construct(
+        IndexName $indexName,
+        IndexerProgressHandler $progressHandler,
+        IndexingAborter $aborter,
+        private readonly SolrIndexService $indexService,
+        IndexerConfigurationLoader $configLoader,
+        private readonly SolrXmlReader $xmlReader,
+        string $source,
+    ) {
+        parent::__construct(
+            $indexName,
+            $progressHandler,
+            $aborter,
+            $configLoader,
+            $source,
+        );
+    }
+
+    public function index(): IndexerStatus
+    {
+        $parameter = $this->loadIndexerParameter();
+
+        if (empty($parameter->xmlFileList)) {
+            return $this->progressHandler->getStatus();
+        }
+
+        $count = 0;
+        foreach ($parameter->xmlFileList as $xmlFile) {
+            $this->xmlReader->open($xmlFile);
+            $count += $this->xmlReader->count();
+        }
+
+        $this->progressHandler->start($count);
+
+        $processId = uniqid('', true);
+        $successCount = 0;
+
+        foreach ($parameter->xmlFileList as $xmlFile) {
+            $this->xmlReader->open($xmlFile);
+            while (
+                ($docList = $this->xmlReader->next($parameter->chunkSize))
+            ) {
+                if (
+                    $this->isAbortionRequested()
+                ) {
+                    return $this->progressHandler->getStatus();
+                }
+                $updater = $this->indexService->updater(ResourceLanguage::default());
+
+                foreach ($docList as $docFields) {
+                    /** @var IndexSchema2xDocument $doc */
+                    $doc = $updater->createDocument();
+                    $doc->crawl_process_id = $processId;
+                    $doc->sp_source = [$this->source];
+                    foreach ($docFields as $name => $value) {
+                        if (empty($value)) {
+                            continue;
+                        }
+                        $doc->addField($name, $value);
+                    }
+                    $successCount++;
+                    $updater->addDocument($doc);
+                }
+                $result = $updater->update();
+                $this->progressHandler->advance(count($docList));
+
+                if ($result->getStatus() !== 0) {
+                    $this->progressHandler->error(new Exception(
+                        $result->getResponse()->getStatusMessage(),
+                    ));
+                }
+                gc_collect_cycles();
+            }
+        }
+
+        if (
+            $successCount >= $parameter->cleanupThreshold
+        ) {
+            $this->indexService->deleteExcludingProcessId(
+                ResourceLanguage::default(),
+                $this->source,
+                $processId,
+            );
+        }
+
+        $this->indexService->commit(ResourceLanguage::default());
+
+        $this->progressHandler->finish();
+        gc_collect_cycles();
+
+        return $this->progressHandler->getStatus();
+
+    }
+
+    public function remove(array $idList): void
+    {
+        $this->indexService->deleteByIdListForAllLanguages(
+            $this->source,
+            $idList,
+        );
+    }
+
+    public function getIndex(ResourceLanguage $lang): string
+    {
+        return $this->indexService->getIndex($lang);
+    }
+
+    private function loadIndexerParameter(): SolrXmlIndexerParameter
+    {
+        $config = $this->configLoader->load($this->source);
+        $data = $config->data;
+
+        /** @var array<string> $xmlFileList */
+        $xmlFileList = $data->getArray('xmlFileList');
+
+        return new SolrXmlIndexerParameter(
+            source: $this->source,
+            cleanupThreshold: $data->getInt('cleanupThreshold'),
+            chunkSize: $data->getInt('chunkSize'),
+            xmlFileList: $xmlFileList,
+        );
+    }
+}

--- a/src/Service/Indexer/SolrXmlIndexerScheduler.php
+++ b/src/Service/Indexer/SolrXmlIndexerScheduler.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Search\Service\Indexer;
+
+use Atoolo\Resource\ResourceLanguage;
+use Atoolo\Search\Dto\Indexer\SolrXmlIndexerEvent;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\Store\SemaphoreStore;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Scheduler\RecurringMessage;
+use Symfony\Component\Scheduler\Schedule;
+use Symfony\Component\Scheduler\ScheduleProviderInterface;
+
+#[AsMessageHandler]
+class SolrXmlIndexerScheduler implements ScheduleProviderInterface
+{
+    private ?Schedule $schedule = null;
+
+    public function __construct(
+        private readonly string $cron,
+        private readonly SolrXmlIndexer $indexer,
+        private readonly LockFactory $lockFactory = new LockFactory(
+            new SemaphoreStore(),
+        ),
+        private readonly LoggerInterface $logger = new NullLogger(),
+    ) {}
+
+    public function getSchedule(): Schedule
+    {
+        $source = $this->indexer->getSource();
+        $name = $this->indexer->getIndex(ResourceLanguage::default());
+        return $this->schedule ??= (new Schedule())
+            ->add(
+                RecurringMessage::cron(
+                    $this->cron,
+                    new SolrXmlIndexerEvent(),
+                ),
+            )->lock($this->lockFactory->createLock(
+                'solr-xml-indexer-scheduler-'
+                        . $source
+                        . '-'
+                        . $name,
+            ));
+    }
+
+    public function __invoke(SolrXmlIndexerEvent $message): void
+    {
+        $status = $this->indexer->index();
+        $this->logger->info("indexer finish: " . $status->getStatusLine());
+    }
+}

--- a/src/Service/Indexer/SolrXmlReader.php
+++ b/src/Service/Indexer/SolrXmlReader.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Search\Service\Indexer;
+
+use Atoolo\Resource\ResourceChannel;
+use Exception;
+use LogicException;
+use RuntimeException;
+use XMLReader;
+
+class SolrXmlReader
+{
+    private ?XMLReader $xmlReader = null;
+
+    private string $xmlUri;
+
+    public function __construct(
+        private readonly ResourceChannel $resourceChannel,
+    ) {}
+
+    public function open(string $xmlUri): void
+    {
+        if (
+            !filter_var($xmlUri, FILTER_VALIDATE_URL)
+            && !file_exists($xmlUri)
+        ) {
+            $xmlUri = $this->resourceChannel->baseDir . '/media/public' . $xmlUri;
+        }
+        $this->xmlUri = $xmlUri;
+
+        $this->xmlReader?->close();
+
+        $reader = @XmlReader::open($this->xmlUri);
+        if ($reader === false) {
+            throw new RuntimeException('Could not open XML URI ' . $this->xmlUri);
+        }
+        $this->xmlReader = $reader;
+    }
+
+    public function count(): int
+    {
+        if ($this->xmlReader === null) {
+            throw new LogicException('XML file is not open');
+        }
+        $count = 0;
+        while ($this->xmlReader->read()) {
+            if (
+                $this->nodeType() === XMLReader::ELEMENT
+                && $this->tagName() === 'doc'
+            ) {
+                $count++;
+            }
+        }
+        $this->open($this->xmlUri); // reset the reader (close and open again)
+        return $count;
+    }
+
+    /**
+     * @param int $count
+     * @return array<array<string,string|array<string>>>
+     * @throws Exception
+     */
+    public function next(int $count): array
+    {
+        if ($this->xmlReader === null) {
+            throw new LogicException('XML file is not open');
+        }
+
+        $docList = [];
+        while ($this->xmlReader->read()) {
+            if (
+                $this->nodeType() === XMLReader::ELEMENT
+                && $this->tagName() === 'doc'
+            ) {
+                $docList[] = $this->readDoc();
+                if (count($docList) === $count) {
+                    break;
+                }
+            }
+        }
+        return $docList;
+    }
+
+    /**
+     * @throws Exception
+     * @return array<string,string|array<string>>
+     */
+    private function readDoc(): array
+    {
+
+        // cannot occur, but phpstan is then happy
+        // @codeCoverageIgnoreStart
+        if ($this->xmlReader === null) {
+            throw new LogicException('XML file is not open');
+        }
+        // @codeCoverageIgnoreEnd
+
+        $doc = [];
+        while (@$this->xmlReader->read()) {
+            if (
+                $this->nodeType() === XMLReader::END_ELEMENT
+                && $this->tagName() === 'doc'
+            ) {
+                return $doc;
+            }
+
+            if (
+                $this->nodeType() !== XMLReader::ELEMENT
+            ) {
+                continue;
+            }
+
+            if ($this->tagName() !== 'field') {
+                continue;
+            }
+
+            $name = $this->xmlReader->getAttribute('name');
+            $value = $this->xmlReader->readString();
+
+            if (!isset($doc[$name])) {
+                $doc[$name] = $value;
+            } else {
+                if (!is_array($doc[$name])) {
+                    $doc[$name] = [$doc[$name]];
+                }
+                $doc[$name][] = $value;
+            }
+        }
+        throw new RuntimeException('Unexpected end of XML');
+    }
+
+    private function nodeType(): int
+    {
+        return $this->xmlReader->nodeType ?? XMLReader::NONE;
+    }
+
+    private function tagName(): ?string
+    {
+        return $this->xmlReader->name ?? null;
+    }
+}

--- a/test/Service/Indexer/SolrXmlIndexerSchedulerTest.php
+++ b/test/Service/Indexer/SolrXmlIndexerSchedulerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Search\Test\Service\Indexer;
+
+use Atoolo\Search\Dto\Indexer\SolrXmlIndexerEvent;
+use Atoolo\Search\Service\Indexer\SolrXmlIndexer;
+use Atoolo\Search\Service\Indexer\SolrXmlIndexerScheduler;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SolrXmlIndexerScheduler::class)]
+class SolrXmlIndexerSchedulerTest extends TestCase
+{
+    /**
+     * @throws Exception
+     */
+    public function testGetSchedule(): void
+    {
+        $indexer = $this->createStub(SolrXmlIndexer::class);
+        $scheduler = new SolrXmlIndexerScheduler(
+            '0 2 * * *',
+            $indexer,
+        );
+
+        $schedule = $scheduler->getSchedule();
+
+        $this->assertCount(
+            1,
+            $schedule->getRecurringMessages(),
+        );
+    }
+
+    public function testInvoke(): void
+    {
+        $indexer = $this->createMock(SolrXmlIndexer::class);
+        $scheduler = new SolrXmlIndexerScheduler(
+            '0 2 * * *',
+            $indexer,
+        );
+
+        $indexer->expects($this->once())
+            ->method('index');
+        $scheduler->__invoke(new SolrXmlIndexerEvent());
+    }
+}

--- a/test/Service/Indexer/SolrXmlIndexerTest.php
+++ b/test/Service/Indexer/SolrXmlIndexerTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Search\Test\Service\Indexer;
+
+use Atoolo\Resource\DataBag;
+use Atoolo\Resource\ResourceLanguage;
+use Atoolo\Search\Dto\Indexer\IndexerConfiguration;
+use Atoolo\Search\Service\Indexer\IndexerConfigurationLoader;
+use Atoolo\Search\Service\Indexer\IndexerProgressHandler;
+use Atoolo\Search\Service\Indexer\IndexingAborter;
+use Atoolo\Search\Service\Indexer\SolrIndexService;
+use Atoolo\Search\Service\Indexer\SolrXmlIndexer;
+use Atoolo\Search\Service\Indexer\SolrXmlReader;
+use Atoolo\Search\Service\IndexName;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SolrXmlIndexer::class)]
+class SolrXmlIndexerTest extends TestCase
+{
+    private SolrXmlIndexer $indexer;
+
+    private SolrIndexService&MockObject $indexService;
+
+    private IndexerConfigurationLoader&Stub $configLoader;
+
+    private IndexerProgressHandler&MockObject $progressHandler;
+
+    private SolrXmlReader&Stub $xmlReader;
+
+    private IndexingAborter&Stub $aborter;
+
+    /**
+     * @throws Exception
+     */
+    public function setUp(): void
+    {
+        $indexName = $this->createStub(IndexName::class);
+        $this->progressHandler = $this->createMock(IndexerProgressHandler::class);
+        $this->aborter = $this->createStub(IndexingAborter::class);
+        $this->indexService = $this->createMock(SolrIndexService::class);
+        $this->configLoader = $this->createStub(IndexerConfigurationLoader::class);
+        $this->xmlReader = $this->createStub(SolrXmlReader::class);
+
+        $this->indexer = new SolrXmlIndexer(
+            $indexName,
+            $this->progressHandler,
+            $this->aborter,
+            $this->indexService,
+            $this->configLoader,
+            $this->xmlReader,
+            'source',
+        );
+    }
+
+    public function testRemove(): void
+    {
+        $this->indexService->expects($this->once())
+            ->method('deleteByIdListForAllLanguages');
+        $this->indexer->remove(['123']);
+    }
+
+    public function testGetIndex(): void
+    {
+        $lang = $this->createStub(ResourceLanguage::class);
+        $this->indexService->expects($this->once())
+            ->method('getIndex');
+        $this->indexer->getIndex($lang);
+    }
+
+    public function testIndexWithEmptyXmlFileList(): void
+    {
+        $this->configLoader->method('load')
+            ->willReturn(new IndexerConfiguration(
+                source: 'test',
+                name: 'test',
+                data: new DataBag([
+                    'xmlFileList' => [],
+                    'cleanupThreshold' => '1000',
+                    'chunkSize' => '500',
+                ]),
+            ));
+
+        $this->progressHandler->expects($this->never())
+            ->method('start');
+        $this->progressHandler->expects($this->once())
+            ->method('getStatus');
+
+        $this->indexer->index();
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testIndex(): void
+    {
+        $this->configLoader->method('load')
+            ->willReturn(new IndexerConfiguration(
+                source: 'test',
+                name: 'test',
+                data: new DataBag([
+                    'xmlFileList' => ['/test.xml'],
+                    'cleanupThreshold' => '1000',
+                    'chunkSize' => '500',
+                ]),
+            ));
+        $this->xmlReader->method('count')
+            ->willReturn(1);
+
+        $this->xmlReader->method('next')
+            ->willReturn(
+                [
+                    [
+                        'id' => '1',
+                        'name' => 'test',
+                        'emptyField' => '',
+                    ],
+                ],
+                [],
+            );
+
+        $this->progressHandler->expects($this->once())
+            ->method('start')
+            ->with(1);
+        $this->progressHandler->expects($this->once())
+            ->method('advance')
+            ->with(1);
+
+        $this->indexer->index();
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testIndexIfAbortionRequested(): void
+    {
+        $this->configLoader->method('load')
+            ->willReturn(new IndexerConfiguration(
+                source: 'test',
+                name: 'test',
+                data: new DataBag([
+                    'xmlFileList' => ['/test.xml'],
+                    'cleanupThreshold' => '1000',
+                    'chunkSize' => '500',
+                ]),
+            ));
+        $this->xmlReader->method('count')
+            ->willReturn(1);
+
+        $this->xmlReader->method('next')
+            ->willReturn(
+                [
+                    [
+                        'id' => '1',
+                        'name' => 'test',
+                        'emptyField' => '',
+                    ],
+                ],
+                [],
+            );
+
+        $this->aborter->method('isAbortionRequested')
+            ->willReturn(true);
+
+        $this->progressHandler->expects($this->once())
+            ->method('start')
+            ->with(1);
+        $this->progressHandler->expects($this->never())
+            ->method('advance');
+
+        $this->indexer->index();
+    }
+}

--- a/test/Service/Indexer/SolrXmlReaderTest.php
+++ b/test/Service/Indexer/SolrXmlReaderTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Search\Test\Service\Indexer;
+
+use Atoolo\Resource\ResourceChannel;
+use Atoolo\Search\Service\Indexer\SolrXmlReader;
+use Exception;
+use LogicException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+#[CoversClass(SolrXmlReader::class)]
+class SolrXmlReaderTest extends TestCase
+{
+    private string $resourceDir = __DIR__
+        . '/../../resources/Service/Indexer/SolrXmlReader';
+
+    private SolrXmlReader $reader;
+
+    public function setUp(): void
+    {
+        $this->reader = new SolrXmlReader(new ResourceChannel(
+            id: '',
+            name: '',
+            anchor: '',
+            serverName: '',
+            isPreview: false,
+            nature: '',
+            locale: '',
+            baseDir: $this->resourceDir,
+            resourceDir: '',
+            configDir: '',
+            searchIndex: '',
+            translationLocales: [],
+        ));
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testOpenWithInvalidFile(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->reader->open('not-exists.xml');
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testCountWithoutOpen(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->reader->count();
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testCount(): void
+    {
+        $this->reader->open('/data.xml');
+        $this->assertEquals(
+            1,
+            $this->reader->count(),
+            '1 document expected',
+        );
+    }
+
+    /**
+     * @throws Exception|\PHPUnit\Framework\MockObject\Exception
+     */
+    public function testNextWithoutOpen(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->reader->next(1);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testNext(): void
+    {
+        $this->reader->open('/data.xml');
+        $docs = $this->reader->next(1);
+
+        $expected = [
+            [
+                "id" => "123",
+                "sp_source" => "test",
+                "title" => "Test",
+                "arrayfield" => ["Test1", "Test2"],
+            ],
+        ];
+
+        $this->assertEquals(
+            $expected,
+            $docs,
+            'unexpected doc',
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testNextWithInvalidXml(): void
+    {
+        $this->reader->open('/invalid.xml');
+        $this->expectException(RuntimeException::class);
+        $this->reader->next(1);
+    }
+}

--- a/test/resources/Service/Indexer/SolrXmlReader/media/public/data.xml
+++ b/test/resources/Service/Indexer/SolrXmlReader/media/public/data.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<add>
+	<doc>
+		<field name="id">123</field>
+		<field name="sp_source">test</field>
+		<field name="title">Test</field>
+		<field name="arrayfield">Test1</field>
+		<field name="arrayfield">Test2</field>
+		<ignore/>
+	</doc>
+</add>

--- a/test/resources/Service/Indexer/SolrXmlReader/media/public/invalid.xml
+++ b/test/resources/Service/Indexer/SolrXmlReader/media/public/invalid.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<add>
+	<doc>
+		<field name="id">123</field>
+		<end></end>


### PR DESCRIPTION
In order to better convert systems with existing indexers, the SolrXMLIndexer can be used to read the existing Solr-XML files and thus integrate them into the Atoolo-Indexer technology.