### PR TITLE
feat: added field 'id' to solr search query

### DIFF
--- a/src/Service/Search/SolrSearch.php
+++ b/src/Service/Search/SolrSearch.php
@@ -121,6 +121,7 @@ class SolrSearch implements Search
             'url',
             'title',
             'description',
+            'id',
             'sp_id',
             'sp_objecttype',
         ]);
@@ -265,7 +266,7 @@ class SolrSearch implements Search
         $facetGroupList = $this->buildFacetGroupList($query, $result);
 
         return new SearchResult(
-            total:$result->getNumFound() ?? 0,
+            total: $result->getNumFound() ?? 0,
             limit: $query->limit,
             offset: $query->offset,
             results: $resourceList,


### PR DESCRIPTION
Adds field 'id' to the default solr search query

The [ExternalResourceFactory](https://github.com/sitepark/atoolo-search-bundle/blob/9e1dc044855623ac826425601d5ff5613e74ce0d/src/Service/Search/ExternalResourceFactory.php#L43C17-L43C50)  tries to read the field `id` from the result document, but it's currently always empty as it's not part of the query. This leads to external resources always having an empty id.
