### PR TITLE
feat: added solr query fields

### DIFF
--- a/src/Service/Search/SolrSearch.php
+++ b/src/Service/Search/SolrSearch.php
@@ -29,6 +29,20 @@ use Solarium\QueryType\Select\Result\Result as SelectResult;
  */
 class SolrSearch implements Search
 {
+    public const QUERY_FIELDS_REQUIRED = [
+        'url',
+        'title',
+        'description',
+        'id',
+        'sp_id',
+        'sp_objecttype',
+        'sp_date',
+        'sp_date_list',
+        'sp_date_from',
+        'sp_date_to',
+        'sp_meta_*'
+    ];
+
     /**
      * @param iterable<SolrQueryModifier> $solrQueryModifierList
      */
@@ -117,14 +131,9 @@ class SolrSearch implements Search
     private function addRequiredFieldListToSolrQuery(
         SolrSelectQuery $solrQuery,
     ): void {
-        $solrQuery->setFields([
-            'url',
-            'title',
-            'description',
-            'id',
-            'sp_id',
-            'sp_objecttype',
-        ]);
+        $solrQuery->setFields(
+            self::QUERY_FIELDS_REQUIRED
+        );
     }
 
     private function addTextFilterToSolrQuery(

--- a/src/Service/Search/SolrSearch.php
+++ b/src/Service/Search/SolrSearch.php
@@ -40,7 +40,7 @@ class SolrSearch implements Search
         'sp_date_list',
         'sp_date_from',
         'sp_date_to',
-        'sp_meta_*'
+        'sp_meta_*',
     ];
 
     /**
@@ -132,7 +132,7 @@ class SolrSearch implements Search
         SolrSelectQuery $solrQuery,
     ): void {
         $solrQuery->setFields(
-            self::QUERY_FIELDS_REQUIRED
+            self::QUERY_FIELDS_REQUIRED,
         );
     }
 

--- a/src/Service/Search/SolrSearch.php
+++ b/src/Service/Search/SolrSearch.php
@@ -38,8 +38,6 @@ class SolrSearch implements Search
         'sp_objecttype',
         'sp_date',
         'sp_date_list',
-        'sp_date_from',
-        'sp_date_to',
         'sp_meta_*',
     ];
 


### PR DESCRIPTION
adds more fields to the solr query as they are required in some contexts, e.g. for ExternalResourceFactories 
- `sp_date`
- `sp_date_start`
- `sp_date_to`
- `sp_date_list`
- `sp_meta_*`

I think that it might not be the best idea to hardcode those fields though, because they are not needed in all contexts. For example a graphql search that does not query any dates/event dates or does not expect external resources, would not require the fields, which would cause unnecessary overhead. (Or is this negligible?).

