### PR TITLE
feat: explain support to analyse results

### DIFF
--- a/config/search.yaml
+++ b/config/search.yaml
@@ -50,10 +50,14 @@ services:
     class: Atoolo\Search\Service\Search\SolrResultToResourceResolver
     arguments:
       - !tagged_iterator atoolo_search.resource_factory
+      - '@atoolo_search.explain_builder'
       - '@logger'
 
   atoolo_search.field_mapper:
     class: Atoolo\Search\Service\Search\Schema2xFieldMapper
+
+  atoolo_search.explain_builder:
+    class: Atoolo\Search\Service\Search\SolrExplainBuilder
 
   atoolo_search.search:
     class: Atoolo\Search\Service\Search\SolrSearch

--- a/src/Dto/Search/Query/SearchQuery.php
+++ b/src/Dto/Search/Query/SearchQuery.php
@@ -34,5 +34,6 @@ class SearchQuery
         public readonly QueryOperator $defaultQueryOperator,
         public readonly ?DateTimeZone $timeZone,
         public readonly ?Boosting $boosting,
+        public readonly bool $explain = false,
     ) {}
 }

--- a/src/Dto/Search/Query/SearchQueryBuilder.php
+++ b/src/Dto/Search/Query/SearchQueryBuilder.php
@@ -39,6 +39,8 @@ class SearchQueryBuilder
 
     private ?Boosting $boosting = null;
 
+    private bool $explain = false;
+
     public function __construct()
     {
         $this->lang = ResourceLanguage::default();
@@ -168,6 +170,13 @@ class SearchQueryBuilder
         return $this;
     }
 
+    public function explain(
+        bool $explain,
+    ): static {
+        $this->explain = $explain;
+        return $this;
+    }
+
     public function build(): SearchQuery
     {
         return new SearchQuery(
@@ -182,6 +191,7 @@ class SearchQueryBuilder
             defaultQueryOperator: $this->defaultQueryOperator,
             timeZone: $this->timeZone,
             boosting: $this->boosting,
+            explain: $this->explain,
         );
     }
 }

--- a/src/Service/Search/SolrExplainBuilder.php
+++ b/src/Service/Search/SolrExplainBuilder.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Search\Service\Search;
+
+/**
+ * @phpstan-type SolrExplainDetail array{
+ *   value?: float,
+ *   description?: string,
+ *   details?: array<array<string,mixed>>,
+ * }
+ * @phpstan-type ExplainDetail array{
+ *   score: float,
+ *   type: string,
+ *   field: string|null,
+ *   description: string,
+ *   details?: array<array<string,mixed>>,
+ * }
+ */
+class SolrExplainBuilder
+{
+    /**
+     * @param SolrExplainDetail $explain
+     * @return ExplainDetail
+     */
+    public function build(array $explain): array
+    {
+        return $this->buildDetail($explain);
+    }
+
+    /**
+     * @param SolrExplainDetail $detail
+     * @return ExplainDetail
+     */
+    private function buildDetail(array $detail): array
+    {
+
+        $description = $detail['description'] ?? '';
+
+        $modifiedDetails = [];
+        $modifiedDetails['score'] = $detail['value'] ?? 0;
+
+        $type = $this->identifyType($description);
+        $modifiedDetails['type'] = $type;
+
+        $modifiedDetails['field'] = $this->parseField($description);
+        $modifiedDetails['description'] = $description;
+
+        $modifiedSubDetails = [];
+        foreach ($detail['details'] ?? [] as $subDetail) {
+            /** @var SolrExplainDetail $subDetail */
+            $modifiedSubDetails[] = $this->buildDetail($subDetail);
+        }
+        if (!empty($modifiedSubDetails)) {
+            $modifiedDetails['details'] = $modifiedSubDetails;
+        }
+
+        return $modifiedDetails;
+    }
+
+    private function identifyType(string $description): string
+    {
+
+        switch (true) {
+            case str_starts_with($description, 'sum of'):
+                return 'sum';
+            case str_starts_with($description, 'max '): // 'max of' | 'max plus'
+                return 'max';
+            case str_starts_with($description, 'weight'):
+                return 'weight';
+            case str_starts_with($description, 'score'):
+                return 'score';
+            case str_starts_with($description, 'idf, '):
+            case str_starts_with($description, 'idf(), sum of'):
+                return 'idf';
+            case str_starts_with($description, 'tfNorm, ') || strpos($description, 'tf, ') === 0:
+                return 'tf';
+            case str_starts_with($description, 'FunctionQuery'):
+                return 'function';
+            case str_starts_with($description, 'boost'):
+                return 'boost';
+            case stripos($description, 'docFreq') === 0 || stripos(
+                $description,
+                'n, number of documents containing term',
+            ) === 0:
+                return 'docFrequency';
+            case stripos($description, 'docCount') === 0 || stripos(
+                $description,
+                'N, total number of documents with field',
+            ) === 0:
+                return 'docCount';
+            case stripos($description, 'termFreq') === 0 || stripos(
+                $description,
+                'freq, occurrences of term within document',
+            ) === 0:
+                return 'termFrequency';
+            case stripos($description, 'fieldLength') === 0 || stripos($description, 'dl, length of field') === 0:
+                return 'fieldLength';
+            case stripos($description, 'avgFieldLength') === 0 || stripos(
+                $description,
+                'avgdl, average length of field',
+            ) === 0:
+                return 'averageFieldLength';
+            case stripos($description, 'queryNorm') === 0:
+                return 'queryNorm';
+            default:
+                return 'boosting';
+        }
+    }
+
+    private function parseField(string $description): ?string
+    {
+        if (strpos($description, 'weight') !== false) {
+            $matches = [];
+            preg_match_all('/weight\((.*):(.*)\)/', $description, $matches);
+            return $matches[1][0];
+        }
+        return null;
+    }
+}

--- a/test/Dto/Search/Query/SearchQueryBuilderTest.php
+++ b/test/Dto/Search/Query/SearchQueryBuilderTest.php
@@ -169,4 +169,14 @@ class SearchQueryBuilderTest extends TestCase
             'unexpected boosting',
         );
     }
+
+    public function testSetExplain(): void
+    {
+        $this->builder->explain(true);
+        $query = $this->builder->build();
+        $this->assertTrue(
+            $query->explain,
+            'unexpected explain',
+        );
+    }
 }

--- a/test/Service/Search/SolrExplainBuilderTest.php
+++ b/test/Service/Search/SolrExplainBuilderTest.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Search\Test\Service\Search;
+
+use Atoolo\Search\Service\Search\SolrExplainBuilder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SolrExplainBuilder::class)]
+class SolrExplainBuilderTest extends TestCase
+{
+    public function testBuild(): void
+    {
+        $builder = new SolrExplainBuilder();
+        $explain = $builder->build([
+            'value' => 3.2,
+            'description' => 'sum of',
+        ]);
+        $this->assertEquals(
+            [
+                'score' => 3.2,
+                'type' => 'sum',
+                'field' => null,
+                'description' => 'sum of',
+            ],
+            $explain,
+            'unexpected explain',
+        );
+    }
+
+    public function testWithDetails(): void
+    {
+        $builder = new SolrExplainBuilder();
+        $explain = $builder->build([
+            "value" => 4.66247,
+            "description" => "weight(content:section in 2887) [SchemaSimilarity], result of:",
+            "details" => [[
+                "match" => true,
+                "value" => 4.66247,
+                "description" => "score(freq=3.0), computed as boost * idf * tf from:",
+            ]],
+        ]);
+        $this->assertEquals(
+            [
+                'score' => 4.66247,
+                'type' => 'weight',
+                'field' => 'content',
+                'description' => 'weight(content:section in 2887) [SchemaSimilarity], result of:',
+                'details' => [
+                    [
+                        'score' => 4.66247,
+                        'type' => 'score',
+                        'field' => null,
+                        'description' => 'score(freq=3.0), computed as boost * idf * tf from:',
+                    ],
+                ],
+            ],
+            $explain,
+            'unexpected explain',
+        );
+    }
+
+    public function testTypeSum(): void
+    {
+        $this->assertEquals(
+            'sum',
+            $this->buildType('sum of'),
+            'unexpected type',
+        );
+    }
+
+    public function testTypeMax(): void
+    {
+        $this->assertEquals(
+            'max',
+            $this->buildType('max of'),
+            'unexpected type',
+        );
+    }
+
+    public function testTypeWeight(): void
+    {
+        $this->assertEquals(
+            'weight',
+            $this->buildType('weight(content:section in 2892) [SchemaSimilarity], result of:'),
+            'unexpected type',
+        );
+    }
+
+    public function testTypeScore(): void
+    {
+        $this->assertEquals(
+            'score',
+            $this->buildType('score(freq=4.0), computed as boost * idf * tf from:"'),
+            'unexpected type',
+        );
+    }
+
+    public function testTypeIdf(): void
+    {
+        $this->assertEquals(
+            'idf',
+            $this->buildType('idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:'),
+            'unexpected type',
+        );
+    }
+
+    public function testTypeTf(): void
+    {
+        $this->assertEquals(
+            'tf',
+            $this->buildType('tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:'),
+            'unexpected type',
+        );
+    }
+
+    public function testTypeFunction(): void
+    {
+        $this->assertEquals(
+            'function',
+            $this->buildType('FunctionQuery(content:section), product of:'),
+            'unexpected type',
+        );
+    }
+
+    public function testTypeBoost(): void
+    {
+        $this->assertEquals(
+            'boost',
+            $this->buildType('boost(1.0), product of:'),
+            'unexpected type',
+        );
+    }
+
+    public function testTypeDocFrequency(): void
+    {
+        $this->assertEquals(
+            'docFrequency',
+            $this->buildType('n, number of documents containing term'),
+            'unexpected type',
+        );
+    }
+
+    public function testTypeDocCount(): void
+    {
+        $this->assertEquals(
+            'docCount',
+            $this->buildType('N, total number of documents with field'),
+            'unexpected type',
+        );
+    }
+
+    public function testTypeTermFrequency(): void
+    {
+        $this->assertEquals(
+            'termFrequency',
+            $this->buildType('freq, occurrences of term within document'),
+            'unexpected type',
+        );
+    }
+
+    public function testTypeFieldLength(): void
+    {
+        $this->assertEquals(
+            'fieldLength',
+            $this->buildType('fieldLength in 2892'),
+            'unexpected type',
+        );
+    }
+
+    public function testTypeAverageFieldLength(): void
+    {
+        $this->assertEquals(
+            'averageFieldLength',
+            $this->buildType('avgdl, average length of field'),
+            'unexpected type',
+        );
+    }
+
+    public function testTypeQueryNorm(): void
+    {
+        $this->assertEquals(
+            'queryNorm',
+            $this->buildType('queryNorm, product of:'),
+            'unexpected type',
+        );
+    }
+
+    public function testDefaultType(): void
+    {
+        $this->assertEquals(
+            'boosting',
+            $this->buildType('other'),
+            'unexpected type',
+        );
+    }
+
+    private function buildType(string $description): string
+    {
+        $builder = new SolrExplainBuilder();
+        $explain = $builder->build([
+            'value' => 3.2,
+            'description' => $description,
+        ]);
+        return $explain['type'];
+    }
+}

--- a/test/Service/Search/SolrResultToResourceResolverTest.php
+++ b/test/Service/Search/SolrResultToResourceResolverTest.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace Atoolo\Search\Test\Service\Search;
 
 use ArrayIterator;
+use Atoolo\Resource\DataBag;
 use Atoolo\Resource\Resource;
 use Atoolo\Resource\ResourceLanguage;
 use Atoolo\Search\Service\Search\ResourceFactory;
+use Atoolo\Search\Service\Search\SolrExplainBuilder;
 use Atoolo\Search\Service\Search\SolrResultToResourceResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\TestCase;
 use Solarium\QueryType\Select\Result\Document;
 use Solarium\QueryType\Select\Result\Result as SelectResult;
@@ -31,7 +34,9 @@ class SolrResultToResourceResolverTest extends TestCase
         $resourceFactory->method('accept')->willReturn(true);
         $resourceFactory->method('create')->willReturn($resource);
 
-        $resolver = new SolrResultToResourceResolver([$resourceFactory]);
+        $explainBuilder = $this->createStub(SolrExplainBuilder::class);
+
+        $resolver = new SolrResultToResourceResolver([$resourceFactory], $explainBuilder);
 
         $resourceList = $resolver->loadResourceList(
             $result,
@@ -57,7 +62,9 @@ class SolrResultToResourceResolverTest extends TestCase
         $resourceFactory = $this->createStub(ResourceFactory::class);
         $resourceFactory->method('accept')->willReturn(false);
 
-        $resolver = new SolrResultToResourceResolver([$resourceFactory]);
+        $explainBuilder = $this->createStub(SolrExplainBuilder::class);
+
+        $resolver = new SolrResultToResourceResolver([$resourceFactory], $explainBuilder);
 
         $resourceList = $resolver->loadResourceList(
             $result,
@@ -81,7 +88,9 @@ class SolrResultToResourceResolverTest extends TestCase
         $resourceFactory = $this->createStub(ResourceFactory::class);
         $resourceFactory->method('accept')->willReturn(false);
 
-        $resolver = new SolrResultToResourceResolver([$resourceFactory]);
+        $explainBuilder = $this->createStub(SolrExplainBuilder::class);
+
+        $resolver = new SolrResultToResourceResolver([$resourceFactory], $explainBuilder);
 
         $resourceList = $resolver->loadResourceList(
             $result,
@@ -91,6 +100,50 @@ class SolrResultToResourceResolverTest extends TestCase
         $this->assertEmpty(
             $resourceList,
             'resourceList should be empty',
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testWithExplain(): void
+    {
+        $document = $this->createStub(Document::class);
+        $document->method('getFields')->willReturn(['explain' => [
+            'value' => 1,
+            'description' => 'test',
+        ]]);
+        $result = $this->createStub(SelectResult::class);
+        $result->method('getIterator')->willReturn(
+            new ArrayIterator([$document]),
+        );
+
+        $resourceFactory = $this->createStub(ResourceFactory::class);
+        $resourceFactory->method('accept')->willReturn(true);
+        $resource = new Resource(
+            'location',
+            'id',
+            'name',
+            'objectType',
+            ResourceLanguage::default(),
+            new DataBag([]),
+        );
+        $resourceFactory->method('create')->willReturn($resource);
+
+        $explainBuilder = $this->createStub(SolrExplainBuilder::class);
+        $explainBuilder->method('build')->willReturn(['score' => 1, 'type' => 'test']);
+
+        $resolver = new SolrResultToResourceResolver([$resourceFactory], $explainBuilder);
+
+        $resourceList = $resolver->loadResourceList(
+            $result,
+            ResourceLanguage::default(),
+        );
+
+        $this->assertEquals(
+            ['score' => 1, 'type' => 'test'],
+            $resourceList[0]->data->getArray('explain'),
+            'unexpected explain',
         );
     }
 }

--- a/test/Service/Search/SolrSearchTest.php
+++ b/test/Service/Search/SolrSearchTest.php
@@ -505,4 +505,29 @@ class SolrSearchTest extends TestCase
 
         $this->searcher->search($query);
     }
+
+    public function testExplain(): void
+    {
+        $query = new SearchQuery(
+            text: '',
+            lang: ResourceLanguage::default(),
+            offset: 0,
+            limit: 10,
+            sort: [],
+            filter: [],
+            facets: [],
+            archive: false,
+            defaultQueryOperator: QueryOperator::OR,
+            timeZone: null,
+            boosting: null,
+            explain: true,
+        );
+
+        $this->solrQuery
+            ->expects($this->once())
+            ->method('addField')
+            ->with('explain:[explain style=nl]');
+
+        $this->searcher->search($query);
+    }
 }


### PR DESCRIPTION
With the help of `explain` the query can be analyzed in order to understand why the hits were found and why they were delivered in the specified order.