### PR TITLE
feat: spatial search

### DIFF
--- a/src/Dto/Search/Query/Facet/SpatialDistanceRangeFacet.php
+++ b/src/Dto/Search/Query/Facet/SpatialDistanceRangeFacet.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Search\Dto\Search\Query\Facet;
+
+use Atoolo\Search\Dto\Search\Query\GeoPoint;
+
+/**
+ * @codeCoverageIgnore
+ */
+class SpatialDistanceRangeFacet extends Facet
+{
+    public function __construct(
+        string $key,
+        public readonly GeoPoint $point,
+        public readonly float $from,
+        public readonly float $to,
+        array $excludeFilter = [],
+    ) {
+        parent::__construct($key, $excludeFilter);
+    }
+}

--- a/src/Dto/Search/Query/Filter/SpatialArbitraryRectangleFilter.php
+++ b/src/Dto/Search/Query/Filter/SpatialArbitraryRectangleFilter.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Search\Dto\Search\Query\Filter;
+
+use Atoolo\Search\Dto\Search\Query\GeoPoint;
+
+/**
+ * @codeCoverageIgnore
+ */
+class SpatialArbitraryRectangleFilter extends Filter
+{
+    public function __construct(
+        public readonly GeoPoint $lowerLeftCorner,
+        public readonly GeoPoint $upperRightCorner,
+        ?string $key = null,
+    ) {
+        parent::__construct($key);
+    }
+}

--- a/src/Dto/Search/Query/Filter/SpatialOrbitalFilter.php
+++ b/src/Dto/Search/Query/Filter/SpatialOrbitalFilter.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Search\Dto\Search\Query\Filter;
+
+use Atoolo\Search\Dto\Search\Query\GeoPoint;
+
+/**
+ * @codeCoverageIgnore
+ */
+class SpatialOrbitalFilter extends Filter
+{
+    public function __construct(
+        /** The radial distance in kilometers */
+        public readonly float $distance,
+        public readonly GeoPoint $centerPoint,
+        public readonly SpatialOrbitalMode $mode = SpatialOrbitalMode::GREAT_CIRCLE_DISTANCE,
+        ?string $key = null,
+    ) {
+        parent::__construct($key);
+    }
+}

--- a/src/Dto/Search/Query/Filter/SpatialOrbitalMode.php
+++ b/src/Dto/Search/Query/Filter/SpatialOrbitalMode.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Search\Dto\Search\Query\Filter;
+
+/**
+ * @codeCoverageIgnore
+ */
+enum SpatialOrbitalMode: string
+{
+    case GREAT_CIRCLE_DISTANCE = 'great-circle-distance';
+    case BOUNDING_BOX = 'bounding-box';
+}

--- a/src/Dto/Search/Query/GeoPoint.php
+++ b/src/Dto/Search/Query/GeoPoint.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Search\Dto\Search\Query;
+
+/**
+ * @codeCoverageIgnore
+ */
+class GeoPoint
+{
+    public function __construct(
+        public readonly float $lng,
+        public readonly float $lat,
+    ) {}
+}

--- a/src/Dto/Search/Query/SearchQuery.php
+++ b/src/Dto/Search/Query/SearchQuery.php
@@ -34,6 +34,7 @@ class SearchQuery
         public readonly QueryOperator $defaultQueryOperator,
         public readonly ?DateTimeZone $timeZone,
         public readonly ?Boosting $boosting,
+        public readonly ?GeoPoint $distanceReferencePoint,
         public readonly bool $explain = false,
     ) {}
 }

--- a/src/Dto/Search/Query/SearchQueryBuilder.php
+++ b/src/Dto/Search/Query/SearchQueryBuilder.php
@@ -39,6 +39,8 @@ class SearchQueryBuilder
 
     private ?Boosting $boosting = null;
 
+    private ?GeoPoint $distanceReferencePoint = null;
+
     private bool $explain = false;
 
     public function __construct()
@@ -170,6 +172,13 @@ class SearchQueryBuilder
         return $this;
     }
 
+    public function distanceReferencePoint(
+        GeoPoint $distanceReferencePoint,
+    ): static {
+        $this->distanceReferencePoint = $distanceReferencePoint;
+        return $this;
+    }
+
     public function explain(
         bool $explain,
     ): static {
@@ -191,6 +200,7 @@ class SearchQueryBuilder
             defaultQueryOperator: $this->defaultQueryOperator,
             timeZone: $this->timeZone,
             boosting: $this->boosting,
+            distanceReferencePoint: $this->distanceReferencePoint,
             explain: $this->explain,
         );
     }

--- a/src/Dto/Search/Query/Sort/SpatialDist.php
+++ b/src/Dto/Search/Query/Sort/SpatialDist.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Search\Dto\Search\Query\Sort;
+
+use Atoolo\Search\Dto\Search\Query\GeoPoint;
+
+/**
+ * @codeCoverageIgnore
+ */
+class SpatialDist extends Criteria
+{
+    public function __construct(
+        Direction $direction,
+        public readonly GeoPoint $point,
+    ) {
+        parent::__construct($direction);
+    }
+}

--- a/test/Dto/Search/Query/SearchQueryBuilderTest.php
+++ b/test/Dto/Search/Query/SearchQueryBuilderTest.php
@@ -8,6 +8,7 @@ use Atoolo\Resource\ResourceLanguage;
 use Atoolo\Search\Dto\Search\Query\Boosting;
 use Atoolo\Search\Dto\Search\Query\Facet\Facet;
 use Atoolo\Search\Dto\Search\Query\Filter\Filter;
+use Atoolo\Search\Dto\Search\Query\GeoPoint;
 use Atoolo\Search\Dto\Search\Query\QueryOperator;
 use Atoolo\Search\Dto\Search\Query\SearchQueryBuilder;
 use Atoolo\Search\Dto\Search\Query\Sort\Criteria;
@@ -167,6 +168,18 @@ class SearchQueryBuilderTest extends TestCase
             $boosting,
             $query->boosting,
             'unexpected boosting',
+        );
+    }
+
+    public function testSetDistanceReferencePoint(): void
+    {
+        $point = new GeoPoint(1, 2);
+        $this->builder->distanceReferencePoint($point);
+        $query = $this->builder->build();
+        $this->assertSame(
+            $point,
+            $query->distanceReferencePoint,
+            'unexpected distanceReferencePoint',
         );
     }
 

--- a/test/Service/Search/Schema2xFieldMapperTest.php
+++ b/test/Service/Search/Schema2xFieldMapperTest.php
@@ -13,7 +13,6 @@ use Atoolo\Search\Dto\Search\Query\Facet\ObjectTypeFacet;
 use Atoolo\Search\Dto\Search\Query\Facet\RelativeDateRangeFacet;
 use Atoolo\Search\Dto\Search\Query\Facet\SiteFacet;
 use Atoolo\Search\Dto\Search\Query\Filter\AbsoluteDateRangeFilter;
-use Atoolo\Search\Dto\Search\Query\Filter\ArchiveFilter;
 use Atoolo\Search\Dto\Search\Query\Filter\CategoryFilter;
 use Atoolo\Search\Dto\Search\Query\Filter\ContentSectionTypeFilter;
 use Atoolo\Search\Dto\Search\Query\Filter\Filter;
@@ -22,13 +21,18 @@ use Atoolo\Search\Dto\Search\Query\Filter\IdFilter;
 use Atoolo\Search\Dto\Search\Query\Filter\ObjectTypeFilter;
 use Atoolo\Search\Dto\Search\Query\Filter\RelativeDateRangeFilter;
 use Atoolo\Search\Dto\Search\Query\Filter\SiteFilter;
+use Atoolo\Search\Dto\Search\Query\Filter\SpatialArbitraryRectangleFilter;
+use Atoolo\Search\Dto\Search\Query\Filter\SpatialOrbitalFilter;
+use Atoolo\Search\Dto\Search\Query\GeoPoint;
 use Atoolo\Search\Dto\Search\Query\Sort\Criteria;
 use Atoolo\Search\Dto\Search\Query\Sort\CustomField;
 use Atoolo\Search\Dto\Search\Query\Sort\Date;
+use Atoolo\Search\Dto\Search\Query\Sort\Direction;
 use Atoolo\Search\Dto\Search\Query\Sort\Headline;
 use Atoolo\Search\Dto\Search\Query\Sort\Name;
 use Atoolo\Search\Dto\Search\Query\Sort\Natural;
 use Atoolo\Search\Dto\Search\Query\Sort\Score;
+use Atoolo\Search\Dto\Search\Query\Sort\SpatialDist;
 use Atoolo\Search\Service\Search\Schema2xFieldMapper;
 use Exception;
 use InvalidArgumentException;
@@ -76,6 +80,8 @@ class Schema2xFieldMapperTest extends TestCase
             [ SiteFilter::class, 'sp_site' ],
             [ RelativeDateRangeFilter::class, 'sp_date_list' ],
             [ AbsoluteDateRangeFilter::class, 'sp_date_list' ],
+            [ SpatialOrbitalFilter::class, 'sp_geo_points' ],
+            [ SpatialArbitraryRectangleFilter::class, 'sp_geo_points' ],
         ];
     }
 
@@ -156,6 +162,15 @@ class Schema2xFieldMapperTest extends TestCase
         $criteria = $this->createStub($sortCriteriaClass);
         $this->assertEquals(
             $expected,
+            $this->mapper->getSortField($criteria),
+        );
+    }
+
+    public function testGetSortSpatialDistField(): void
+    {
+        $criteria = new SpatialDist(Direction::ASC, new GeoPoint(1, 2));
+        $this->assertEquals(
+            'geodist(sp_geo_points,2,1)',
             $this->mapper->getSortField($criteria),
         );
     }

--- a/test/Service/Search/SolrQueryFacetAppenderTest.php
+++ b/test/Service/Search/SolrQueryFacetAppenderTest.php
@@ -10,6 +10,8 @@ use Atoolo\Search\Dto\Search\Query\Facet\MultiQueryFacet;
 use Atoolo\Search\Dto\Search\Query\Facet\ObjectTypeFacet;
 use Atoolo\Search\Dto\Search\Query\Facet\QueryFacet;
 use Atoolo\Search\Dto\Search\Query\Facet\RelativeDateRangeFacet;
+use Atoolo\Search\Dto\Search\Query\Facet\SpatialDistanceRangeFacet;
+use Atoolo\Search\Dto\Search\Query\GeoPoint;
 use Atoolo\Search\Service\Search\Schema2xFieldMapper;
 use Atoolo\Search\Service\Search\SolrQueryFacetAppender;
 use DateInterval;
@@ -275,6 +277,26 @@ class SolrQueryFacetAppenderTest extends TestCase
                 null,
                 null,
                 ['exclude'],
+            ),
+        );
+    }
+
+    public function testAppendGeoDistanceRangeFacet(): void
+    {
+        $this->facetQuery->expects($this->once())
+            ->method('setQuery')
+            ->with('{!frange l=0 u=10}geodist(,10,10)');
+        $this->facetQuery->expects($this->once())
+            ->method('setExcludes')
+            ->with(['geofilter']);
+
+        $this->appender->append(
+            new SpatialDistanceRangeFacet(
+                'mykey',
+                new GeoPoint(10, 10),
+                0,
+                10,
+                ['geofilter'],
             ),
         );
     }

--- a/test/Service/Search/SolrQueryFilterAppenderTest.php
+++ b/test/Service/Search/SolrQueryFilterAppenderTest.php
@@ -12,6 +12,10 @@ use Atoolo\Search\Dto\Search\Query\Filter\NotFilter;
 use Atoolo\Search\Dto\Search\Query\Filter\OrFilter;
 use Atoolo\Search\Dto\Search\Query\Filter\QueryFilter;
 use Atoolo\Search\Dto\Search\Query\Filter\RelativeDateRangeFilter;
+use Atoolo\Search\Dto\Search\Query\Filter\SpatialArbitraryRectangleFilter;
+use Atoolo\Search\Dto\Search\Query\Filter\SpatialOrbitalFilter;
+use Atoolo\Search\Dto\Search\Query\Filter\SpatialOrbitalMode;
+use Atoolo\Search\Dto\Search\Query\GeoPoint;
 use Atoolo\Search\Service\Search\Schema2xFieldMapper;
 use Atoolo\Search\Service\Search\SolrQueryFilterAppender;
 use DateInterval;
@@ -162,6 +166,50 @@ class SolrQueryFilterAppenderTest extends TestCase
         $this->filterQuery->expects($this->once())
             ->method('setQuery')
             ->with('test:[* TO 2021-01-02T00:00:00Z]');
+
+        $this->appender->append($filter);
+    }
+
+    public function testSpatialOrbitalFilterWithGreateCircleDistanceMode(): void
+    {
+        $filter = new SpatialOrbitalFilter(
+            4,
+            new GeoPoint(1, 2),
+            SpatialOrbitalMode::GREAT_CIRCLE_DISTANCE,
+        );
+
+        $this->filterQuery->expects($this->once())
+            ->method('setQuery')
+            ->with('{!geofilt sfield=test pt=2,1 d=4}');
+
+        $this->appender->append($filter);
+    }
+
+    public function testSpatialOrbitalFilterWithBoundingBoxMode(): void
+    {
+        $filter = new SpatialOrbitalFilter(
+            4,
+            new GeoPoint(1, 2),
+            SpatialOrbitalMode::BOUNDING_BOX,
+        );
+
+        $this->filterQuery->expects($this->once())
+            ->method('setQuery')
+            ->with('{!bbox sfield=test pt=2,1 d=4}');
+
+        $this->appender->append($filter);
+    }
+
+    public function testSpatialArbitraryRectangleFilter(): void
+    {
+        $filter = new SpatialArbitraryRectangleFilter(
+            new GeoPoint(1, 2),
+            new GeoPoint(3, 4),
+        );
+
+        $this->filterQuery->expects($this->once())
+            ->method('setQuery')
+            ->with('test:[ 2,1 TO 4,3 ]');
 
         $this->appender->append($filter);
     }

--- a/test/Service/Search/SolrSearchTest.php
+++ b/test/Service/Search/SolrSearchTest.php
@@ -11,6 +11,7 @@ use Atoolo\Search\Dto\Search\Query\Facet\MultiQueryFacet;
 use Atoolo\Search\Dto\Search\Query\Facet\ObjectTypeFacet;
 use Atoolo\Search\Dto\Search\Query\Facet\QueryFacet;
 use Atoolo\Search\Dto\Search\Query\Filter\ObjectTypeFilter;
+use Atoolo\Search\Dto\Search\Query\GeoPoint;
 use Atoolo\Search\Dto\Search\Query\QueryOperator;
 use Atoolo\Search\Dto\Search\Query\SearchQuery;
 use Atoolo\Search\Dto\Search\Query\Sort\Date;
@@ -87,6 +88,7 @@ class SolrSearchTest extends TestCase
         $schemaFieldMapper = $this->createStub(
             Schema2xFieldMapper::class,
         );
+        $schemaFieldMapper->method('getGeoPointField')->willReturn('geo_points');
 
         $this->searcher = new SolrSearch(
             $indexName,
@@ -111,6 +113,7 @@ class SolrSearchTest extends TestCase
             defaultQueryOperator: QueryOperator::OR,
             timeZone: null,
             boosting: null,
+            distanceReferencePoint: null,
         );
 
         $searchResult = $this->searcher->search($query);
@@ -136,6 +139,7 @@ class SolrSearchTest extends TestCase
             defaultQueryOperator: QueryOperator::OR,
             timeZone: null,
             boosting: null,
+            distanceReferencePoint: null,
         );
 
         $searchResult = $this->searcher->search($query);
@@ -167,6 +171,7 @@ class SolrSearchTest extends TestCase
             defaultQueryOperator: QueryOperator::OR,
             timeZone: null,
             boosting: null,
+            distanceReferencePoint: null,
         );
 
         $searchResult = $this->searcher->search($query);
@@ -176,6 +181,30 @@ class SolrSearchTest extends TestCase
             $searchResult->results,
             'unexpected results',
         );
+    }
+
+    public function testSelectWithDistanceField(): void
+    {
+        $query = new SearchQuery(
+            text: '',
+            lang: ResourceLanguage::default(),
+            offset: 0,
+            limit: 10,
+            sort: [],
+            filter: [],
+            facets: [],
+            archive: false,
+            defaultQueryOperator: QueryOperator::OR,
+            timeZone: null,
+            boosting: null,
+            distanceReferencePoint: new GeoPoint(3, 4),
+        );
+
+        $this->solrQuery->expects($this->once())
+            ->method('addField')
+            ->with('distance:geodist(geo_points,4,3)');
+
+        $this->searcher->search($query);
     }
 
     public function testSelectWithAndDefaultOperator(): void
@@ -192,6 +221,7 @@ class SolrSearchTest extends TestCase
             defaultQueryOperator: QueryOperator::AND,
             timeZone: null,
             boosting: null,
+            distanceReferencePoint: null,
         );
 
         $searchResult = $this->searcher->search($query);
@@ -219,6 +249,7 @@ class SolrSearchTest extends TestCase
             defaultQueryOperator: QueryOperator::OR,
             timeZone: null,
             boosting: null,
+            distanceReferencePoint: null,
         );
 
         $searchResult = $this->searcher->search($query);
@@ -255,6 +286,7 @@ class SolrSearchTest extends TestCase
             defaultQueryOperator: QueryOperator::OR,
             timeZone: null,
             boosting: null,
+            distanceReferencePoint: null,
         );
 
         $searchResult = $this->searcher->search($query);
@@ -285,6 +317,7 @@ class SolrSearchTest extends TestCase
             defaultQueryOperator: QueryOperator::OR,
             timeZone: null,
             boosting: null,
+            distanceReferencePoint: null,
         );
 
         $this->expectException(InvalidArgumentException::class);
@@ -321,6 +354,7 @@ class SolrSearchTest extends TestCase
             defaultQueryOperator: QueryOperator::OR,
             timeZone: null,
             boosting: null,
+            distanceReferencePoint: null,
         );
 
         $searchResult = $this->searcher->search($query);
@@ -367,6 +401,7 @@ class SolrSearchTest extends TestCase
             defaultQueryOperator: QueryOperator::OR,
             timeZone: null,
             boosting: null,
+            distanceReferencePoint: null,
         );
 
         $searchResult = $this->searcher->search($query);
@@ -419,6 +454,7 @@ class SolrSearchTest extends TestCase
             defaultQueryOperator: QueryOperator::OR,
             timeZone: null,
             boosting: null,
+            distanceReferencePoint: null,
         );
 
         $this->expectException(InvalidArgumentException::class);
@@ -450,6 +486,7 @@ class SolrSearchTest extends TestCase
             defaultQueryOperator: QueryOperator::OR,
             timeZone: null,
             boosting: null,
+            distanceReferencePoint: null,
         );
 
         $searchResult = $this->searcher->search($query);
@@ -474,6 +511,7 @@ class SolrSearchTest extends TestCase
             defaultQueryOperator: QueryOperator::OR,
             timeZone: new DateTimeZone("UTC"),
             boosting: null,
+            distanceReferencePoint: null,
         );
 
         $this->solrQuery->expects($this->once())
@@ -497,6 +535,7 @@ class SolrSearchTest extends TestCase
             defaultQueryOperator: QueryOperator::OR,
             timeZone: null,
             boosting: null,
+            distanceReferencePoint: null,
         );
 
         $this->solrQuery->expects($this->once())
@@ -520,6 +559,7 @@ class SolrSearchTest extends TestCase
             defaultQueryOperator: QueryOperator::OR,
             timeZone: null,
             boosting: null,
+            distanceReferencePoint: null,
             explain: true,
         );
 


### PR DESCRIPTION
The Spatial search includes the following features:

- Specification of the distance (in km) per hit to the reference point.
- Sorting of hits by distance to the reference point
- Filtering of hits by distance to the reference point
- Filtering of hits that are located within a defined rectangle
- Faceting of hits by distance to the reference point

See https://sitepark.github.io/atoolo-docs/develop/graphql/search/#spatial-search