### PR TITLE
feat: content-matcher also requires the resource

### DIFF
--- a/src/Service/Indexer/ContentCollector.php
+++ b/src/Service/Indexer/ContentCollector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Atoolo\Search\Service\Indexer;
 
+use Atoolo\Resource\Resource;
 use Atoolo\Search\Service\Indexer\SiteKit\ContentMatcher;
 
 class ContentCollector
@@ -16,9 +17,9 @@ class ContentCollector
     /**
     * @param array<mixed,mixed> $data
      */
-    public function collect(array $data): string
+    public function collect(array $data, Resource $resource): string
     {
-        $content = $this->walk([], $data);
+        $content = $this->walk([], $data, $resource);
         return implode(' ', $content);
     }
 
@@ -27,7 +28,7 @@ class ContentCollector
      * @param array<mixed,mixed> $data
      * @return string[]
      */
-    private function walk(array $path, array $data): array
+    private function walk(array $path, array $data, Resource $resource): array
     {
         $contentCollections = [];
         foreach ($data as $key => $value) {
@@ -41,14 +42,14 @@ class ContentCollector
 
             $matcherContent = [];
             foreach ($this->matchers as $matcher) {
-                $content = $matcher->match($path, $value);
+                $content = $matcher->match($path, $value, $resource);
                 if (!is_string($content)) {
                     continue;
                 }
                 $matcherContent[] = $content;
             }
             $contentCollections[] = $matcherContent;
-            $contentCollections[] = $this->walk($path, $value);
+            $contentCollections[] = $this->walk($path, $value, $resource);
 
             if (is_string($key)) {
                 array_pop($path);

--- a/src/Service/Indexer/SiteKit/ContentMatcher.php
+++ b/src/Service/Indexer/SiteKit/ContentMatcher.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Atoolo\Search\Service\Indexer\SiteKit;
 
+use Atoolo\Resource\Resource;
+
 /**
  * The `ContentMatcher` interface is implemented in order to extract from the
  * content structure of resources the content that is relevant for the `content`
@@ -31,5 +33,5 @@ interface ContentMatcher
      * @return string|false The extracted content or `false` if the
      *         content is not relevant for the search index.
      */
-    public function match(array $path, array $value): string|false;
+    public function match(array $path, array $value, Resource $resource): string|false;
 }

--- a/src/Service/Indexer/SiteKit/DefaultSchema2xDocumentEnricher.php
+++ b/src/Service/Indexer/SiteKit/DefaultSchema2xDocumentEnricher.php
@@ -284,6 +284,7 @@ class DefaultSchema2xDocumentEnricher implements DocumentEnricher
 
         $content[] = $this->contentCollector->collect(
             $resource->data->getArray('content'),
+            $resource,
         );
 
         /** @var ContactPoint $contactPoint */

--- a/src/Service/Indexer/SiteKit/HeadlineMatcher.php
+++ b/src/Service/Indexer/SiteKit/HeadlineMatcher.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Atoolo\Search\Service\Indexer\SiteKit;
 
+use Atoolo\Resource\Resource;
+
 class HeadlineMatcher implements ContentMatcher
 {
     /**
      * @inheritDoc
      */
-    public function match(array $path, array $value): string|false
+    public function match(array $path, array $value, Resource $resource): string|false
     {
         $len = count($path);
         if ($len < 2) {

--- a/src/Service/Indexer/SiteKit/QuoteSectionMatcher.php
+++ b/src/Service/Indexer/SiteKit/QuoteSectionMatcher.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Atoolo\Search\Service\Indexer\SiteKit;
 
+use Atoolo\Resource\Resource;
+
 /**
  *  @phpstan-type Model array{quote?: ?string, citation?: ?string}
  */
@@ -12,7 +14,7 @@ class QuoteSectionMatcher implements ContentMatcher
     /**
      * @inheritDoc
      */
-    public function match(array $path, array $value): string|false
+    public function match(array $path, array $value, Resource $resource): string|false
     {
         $len = count($path);
         if ($len < 1) {

--- a/src/Service/Indexer/SiteKit/RichtTextMatcher.php
+++ b/src/Service/Indexer/SiteKit/RichtTextMatcher.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Atoolo\Search\Service\Indexer\SiteKit;
 
+use Atoolo\Resource\Resource;
+
 class RichtTextMatcher implements ContentMatcher
 {
     /**
      * @inheritDoc
      */
-    public function match(array $path, array $value): string|false
+    public function match(array $path, array $value, Resource $resource): string|false
     {
         $modelType = $value['modelType'] ?? false;
         if ($modelType !== 'html.richText') {

--- a/test/Service/Indexer/ContentCollectorTest.php
+++ b/test/Service/Indexer/ContentCollectorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Atoolo\Search\Test\Service\Indexer;
 
+use Atoolo\Resource\Resource;
 use Atoolo\Search\Service\Indexer\ContentCollector;
 use Atoolo\Search\Service\Indexer\SiteKit\ContentMatcher;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -15,7 +16,7 @@ class ContentCollectorTest extends TestCase
     public function testCollect(): void
     {
         $matcher = (new class implements ContentMatcher {
-            public function match(array $path, array $value): string|false
+            public function match(array $path, array $value, Resource $resource): string|false
             {
                 $modelType = $value['modelType'] ?? false;
                 if ($modelType !== 'html.richText') {
@@ -41,7 +42,9 @@ class ContentCollectorTest extends TestCase
                 ],
             ],
         ];
-        $content = $collector->collect($data);
+
+        $resource = $this->createStub(Resource::class);
+        $content = $collector->collect($data, $resource);
 
         $this->assertEquals('<p>Ein Text</p>', $content, 'unexpected content');
     }

--- a/test/Service/Indexer/SiteKit/HeadlineMatcherTest.php
+++ b/test/Service/Indexer/SiteKit/HeadlineMatcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Atoolo\Search\Test\Service\Indexer\SiteKit;
 
+use Atoolo\Resource\Resource;
 use Atoolo\Search\Service\Indexer\SiteKit\HeadlineMatcher;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -19,7 +20,8 @@ class HeadlineMatcherTest extends TestCase
             "headline" => "Überschrift",
         ];
 
-        $content = $matcher->match(['items', 'model'], $value);
+        $resource = $this->createStub(Resource::class);
+        $content = $matcher->match(['items', 'model'], $value, $resource);
 
         $this->assertEquals('Überschrift', $content, 'unexpected headline');
     }
@@ -32,7 +34,8 @@ class HeadlineMatcherTest extends TestCase
             "headline" => "Überschrift",
         ];
 
-        $content = $matcher->match(['model'], $value);
+        $resource = $this->createStub(Resource::class);
+        $content = $matcher->match(['model'], $value, $resource);
 
         $this->assertEmpty(
             $content,
@@ -48,7 +51,8 @@ class HeadlineMatcherTest extends TestCase
             "headline" => "Überschrift",
         ];
 
-        $content = $matcher->match(['items', 'modelX'], $value);
+        $resource = $this->createStub(Resource::class);
+        $content = $matcher->match(['items', 'modelX'], $value, $resource);
 
         $this->assertEmpty(
             $content,

--- a/test/Service/Indexer/SiteKit/QuoteSectionMatcherTest.php
+++ b/test/Service/Indexer/SiteKit/QuoteSectionMatcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Atoolo\Search\Test\Service\Indexer\SiteKit;
 
+use Atoolo\Resource\Resource;
 use Atoolo\Search\Service\Indexer\SiteKit\QuoteSectionMatcher;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -23,7 +24,8 @@ class QuoteSectionMatcherTest extends TestCase
             ],
         ];
 
-        $content = $matcher->match(['items'], $value);
+        $resource = $this->createStub(Resource::class);
+        $content = $matcher->match(['items'], $value, $resource);
 
         $this->assertEquals(
             'Quote-Text Citation',
@@ -43,7 +45,8 @@ class QuoteSectionMatcherTest extends TestCase
             ],
         ];
 
-        $content = $matcher->match([], $value);
+        $resource = $this->createStub(Resource::class);
+        $content = $matcher->match([], $value, $resource);
 
         $this->assertEmpty(
             $content,
@@ -63,7 +66,8 @@ class QuoteSectionMatcherTest extends TestCase
             ],
         ];
 
-        $content = $matcher->match(['itemsX'], $value);
+        $resource = $this->createStub(Resource::class);
+        $content = $matcher->match(['itemsX'], $value, $resource);
 
         $this->assertEmpty(
             $content,
@@ -83,7 +87,8 @@ class QuoteSectionMatcherTest extends TestCase
             ],
         ];
 
-        $content = $matcher->match(['items'], $value);
+        $resource = $this->createStub(Resource::class);
+        $content = $matcher->match(['items'], $value, $resource);
 
         $this->assertEmpty(
             $content,
@@ -103,7 +108,8 @@ class QuoteSectionMatcherTest extends TestCase
             ],
         ];
 
-        $content = $matcher->match(['items'], $value);
+        $resource = $this->createStub(Resource::class);
+        $content = $matcher->match(['items'], $value, $resource);
 
         $this->assertEmpty(
             $content,

--- a/test/Service/Indexer/SiteKit/RichtTextMatcherTest.php
+++ b/test/Service/Indexer/SiteKit/RichtTextMatcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Atoolo\Search\Test\Service\Indexer\SiteKit;
 
+use Atoolo\Resource\Resource;
 use Atoolo\Search\Service\Indexer\SiteKit\RichtTextMatcher;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -21,7 +22,8 @@ class RichtTextMatcherTest extends TestCase
             "text" => "<p>Ein Text</p>",
         ];
 
-        $content = $matcher->match([], $value);
+        $resource = $this->createStub(Resource::class);
+        $content = $matcher->match([], $value, $resource);
 
         $this->assertEquals('Ein Text', $content, 'unexpected content');
     }
@@ -36,7 +38,8 @@ class RichtTextMatcherTest extends TestCase
             "text" => "<p>Ein Text</p>",
         ];
 
-        $content = $matcher->match([], $value);
+        $resource = $this->createStub(Resource::class);
+        $content = $matcher->match([], $value, $resource);
 
         $this->assertEmpty(
             $content,
@@ -54,7 +57,8 @@ class RichtTextMatcherTest extends TestCase
             "textX" => "<p>Ein Text</p>",
         ];
 
-        $content = $matcher->match([], $value);
+        $resource = $this->createStub(Resource::class);
+        $content = $matcher->match([], $value, $resource);
 
         $this->assertEmpty(
             $content,


### PR DESCRIPTION
If a resource needs to be reloaded in the content matcher, the language of the current resource is required. This shows that the resource may also be required for other cases.