### PR TITLE
fix(document enricher): event dates -> the order of the results is incorrect

### DIFF
--- a/src/Service/Indexer/SiteKit/DefaultSchema2xDocumentEnricher.php
+++ b/src/Service/Indexer/SiteKit/DefaultSchema2xDocumentEnricher.php
@@ -220,11 +220,18 @@ class DefaultSchema2xDocumentEnricher implements DocumentEnricher
             $doc->sp_date = $this->toDateTime($schedulingList[0]['from']);
             $dateList = [];
             $contentTypeList = [];
+
+            $now = new \DateTime();
+            $currentDay = $now->format('Ymd');
+
             foreach ($schedulingList as $scheduling) {
                 $contentTypeList[] = explode(' ', $scheduling['contentType']);
                 $from = $this->toDateTime($scheduling['from']);
                 if ($from !== null) {
-                    $dateList[] = $from;
+                    $day = $from->format('Ymd');
+                    if ($day >= $currentDay) {
+                        $dateList[] = $from;
+                    }
                 }
             }
             $doc->sp_contenttype = array_merge(


### PR DESCRIPTION
Issue:
The sorting of events with multiple sp_scheduling_iterate is incorrect.  Repeat events that start in the past are always prioritized in order.

Solution:
The idea is to change the list of dates available to the Solr process. Solr only considers the list of current dates for indexing, without dates that are already in the past.