### PR TITLE
feat: added SearchQueryDenormalizer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
         "infection/infection": "^0.27.6",
         "phpcompatibility/php-compatibility": "^9.3",
+        "phpdocumentor/type-resolver": "^1.10",
         "phpunit/phpunit": "^10.4",
         "roave/security-advisories": "dev-latest",
         "squizlabs/php_codesniffer": "^3.7",

--- a/src/Dto/Search/Query/Facet/Facet.php
+++ b/src/Dto/Search/Query/Facet/Facet.php
@@ -4,9 +4,28 @@ declare(strict_types=1);
 
 namespace Atoolo\Search\Dto\Search\Query\Facet;
 
+use Symfony\Component\Serializer\Attribute\DiscriminatorMap;
+
 /**
  * @codeCoverageIgnore
  */
+#[DiscriminatorMap(
+    typeProperty: 'type',
+    mapping: [
+        'absoluteDateRange' => AbsoluteDateRangeFacet::class,
+        'category' => CategoryFacet::class,
+        'contentSectionType' => ContentSectionTypeFacet::class,
+        'contentType' => ContentTypeFacet::class,
+        'group' => GroupFacet::class,
+        'multiQuery' => MultiQueryFacet::class,
+        'objectType' => ObjectTypeFacet::class,
+        'query' => QueryFacet::class,
+        'relativeDateRange' => RelativeDateRangeFacet::class,
+        'site' => SiteFacet::class,
+        'source' => SourceFacet::class,
+        'spatialDistanceRange' => SpatialDistanceRangeFacet::class,
+    ],
+)]
 abstract class Facet
 {
     /**

--- a/src/Dto/Search/Query/Filter/Filter.php
+++ b/src/Dto/Search/Query/Filter/Filter.php
@@ -4,9 +4,33 @@ declare(strict_types=1);
 
 namespace Atoolo\Search\Dto\Search\Query\Filter;
 
+use Symfony\Component\Serializer\Attribute\DiscriminatorMap;
+
 /**
  * @codeCoverageIgnore
  */
+#[DiscriminatorMap(
+    typeProperty: 'type',
+    mapping: [
+        'absoluteDateRange' => AbsoluteDateRangeFilter::class,
+        'and' => AndFilter::class,
+        'category' => CategoryFilter::class,
+        'contentSectionType' => ContentSectionTypeFilter::class,
+        'contentType' => ContentTypeFilter::class,
+        'geoLocated' => GeoLocatedFilter::class,
+        'group' => GroupFilter::class,
+        'id' => IdFilter::class,
+        'not' => NotFilter::class,
+        'objectType' => ObjectTypeFilter::class,
+        'or' => OrFilter::class,
+        'query' => QueryFilter::class,
+        'relativeDateRange' => RelativeDateRangeFilter::class,
+        'site' => SiteFilter::class,
+        'source' => SourceFilter::class,
+        'spatialArbitraryRectangle' => SpatialArbitraryRectangleFilter::class,
+        'spatialOrbital' => SpatialOrbitalFilter::class,
+    ],
+)]
 abstract class Filter
 {
     /**

--- a/src/Dto/Search/Query/Sort/Criteria.php
+++ b/src/Dto/Search/Query/Sort/Criteria.php
@@ -4,9 +4,22 @@ declare(strict_types=1);
 
 namespace Atoolo\Search\Dto\Search\Query\Sort;
 
+use Symfony\Component\Serializer\Attribute\DiscriminatorMap;
+
 /**
  * @codeCoverageIgnore
  */
+#[DiscriminatorMap(
+    typeProperty: 'type',
+    mapping: [
+        'customField' => CustomField::class,
+        'date' => Date::class,
+        'name' => Name::class,
+        'natural' => Natural::class,
+        'score' => Score::class,
+        'spatialDist' => SpatialDist::class,
+    ],
+)]
 abstract class Criteria
 {
     public function __construct(

--- a/src/Dto/Search/Query/Sort/Direction.php
+++ b/src/Dto/Search/Query/Sort/Direction.php
@@ -5,8 +5,8 @@ namespace Atoolo\Search\Dto\Search\Query\Sort;
 /**
  * @codeCoverageIgnore
  */
-enum Direction
+enum Direction: string
 {
-    case ASC;
-    case DESC;
+    case ASC = 'ASC';
+    case DESC = 'DESC';
 }

--- a/src/Serializer/Search/Query/SearchQueryDenormalizer.php
+++ b/src/Serializer/Search/Query/SearchQueryDenormalizer.php
@@ -33,13 +33,7 @@ class SearchQueryDenormalizer implements DenormalizerInterface, DenormalizerAwar
             $builder->text($data['text']);
         }
         if (isset($data['lang'])) {
-            // support both ResourceLanguage::of and constructor
-            if (is_string($data['lang'])) {
-                $builder->lang(ResourceLanguage::of($data['lang']));
-            } else {
-                // @phpstan-ignore argument.type
-                $builder->lang($this->denormalizer->denormalize($data['lang'], ResourceLanguage::class));
-            }
+            $builder->lang(ResourceLanguage::of($data['lang']));
         }
         if (isset($data['offset'])) {
             $builder->offset($data['offset']);

--- a/src/Serializer/Search/Query/SearchQueryDenormalizer.php
+++ b/src/Serializer/Search/Query/SearchQueryDenormalizer.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Atoolo\Search\Serializer\Search\Query;
+
+use Atoolo\Resource\ResourceLanguage;
+use Atoolo\Search\Dto\Search\Query\Boosting;
+use Atoolo\Search\Dto\Search\Query\Facet\Facet;
+use Atoolo\Search\Dto\Search\Query\Filter\Filter;
+use Atoolo\Search\Dto\Search\Query\GeoPoint;
+use Atoolo\Search\Dto\Search\Query\QueryOperator;
+use Atoolo\Search\Dto\Search\Query\SearchQuery;
+use Atoolo\Search\Dto\Search\Query\SearchQueryBuilder;
+use Atoolo\Search\Dto\Search\Query\Sort\Criteria;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+class SearchQueryDenormalizer implements DenormalizerInterface, DenormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+
+    /**
+     * @param array<mixed> $context
+     */
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        if (!is_array($data)) {
+            throw new NotNormalizableValueException(\sprintf('Failed to denormalize data into class "%s": Array expected, %s given', $type, gettype($data)));
+        }
+        $builder = new SearchQueryBuilder();
+        if (isset($data['text'])) {
+            $builder->text($data['text']);
+        }
+        if (isset($data['lang'])) {
+            // support both ResourceLanguage::of and constructor
+            if (is_string($data['lang'])) {
+                $builder->lang(ResourceLanguage::of($data['lang']));
+            } else {
+                // @phpstan-ignore argument.type
+                $builder->lang($this->denormalizer->denormalize($data['lang'], ResourceLanguage::class));
+            }
+        }
+        if (isset($data['offset'])) {
+            $builder->offset($data['offset']);
+        }
+        if (isset($data['limit'])) {
+            $builder->limit($data['limit']);
+        }
+        if (isset($data['sort'])) {
+            // @phpstan-ignore argument.type, argument.unpackNonIterable
+            $builder->sort(...$this->denormalizer->denormalize($data['sort'], Criteria::class . '[]'));
+        }
+        if (isset($data['filter'])) {
+            // @phpstan-ignore argument.type, argument.unpackNonIterable
+            $builder->filter(...$this->denormalizer->denormalize($data['filter'], Filter::class . '[]'));
+        }
+        if (isset($data['facets'])) {
+            // @phpstan-ignore argument.type, argument.unpackNonIterable
+            $builder->facet(...$this->denormalizer->denormalize($data['facets'], Facet::class . '[]'));
+        }
+        if (isset($data['archive'])) {
+            $builder->archive($data['archive']);
+        }
+        if (isset($data['defaultQueryOperator'])) {
+            $builder->defaultQueryOperator(QueryOperator::from($data['defaultQueryOperator']));
+        }
+        if (isset($data['timeZone'])) {
+            $builder->timeZone(new \DateTimeZone($data['timeZone']));
+        }
+        if (isset($data['boosting'])) {
+            // @phpstan-ignore argument.type
+            $builder->boosting($this->denormalizer->denormalize($data['boosting'], Boosting::class));
+        }
+        if (isset($data['distanceReferencePoint'])) {
+            $builder->distanceReferencePoint(
+                // @phpstan-ignore argument.type
+                $this->denormalizer->denormalize($data['distanceReferencePoint'], GeoPoint::class),
+            );
+        }
+        if (isset($data['explain'])) {
+            $builder->explain($data['explain']);
+        }
+        return $builder->build();
+    }
+
+    /**
+     * @param array<mixed> $context
+     */
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === SearchQuery::class;
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            SearchQuery::class => true,
+        ];
+    }
+}

--- a/test/Serializer/Search/Query/SearchQueryDenormalizerTest.php
+++ b/test/Serializer/Search/Query/SearchQueryDenormalizerTest.php
@@ -1,0 +1,425 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Search\Test\Serializer\Search\Query;
+
+use Atoolo\Resource\ResourceLanguage;
+use Atoolo\Search\Dto\Search\Query\Boosting;
+use Atoolo\Search\Dto\Search\Query\DateRangeRound;
+use Atoolo\Search\Dto\Search\Query\Facet\AbsoluteDateRangeFacet;
+use Atoolo\Search\Dto\Search\Query\Facet\CategoryFacet;
+use Atoolo\Search\Dto\Search\Query\Facet\ContentSectionTypeFacet;
+use Atoolo\Search\Dto\Search\Query\Facet\ContentTypeFacet;
+use Atoolo\Search\Dto\Search\Query\Facet\GroupFacet;
+use Atoolo\Search\Dto\Search\Query\Facet\MultiQueryFacet;
+use Atoolo\Search\Dto\Search\Query\Facet\ObjectTypeFacet;
+use Atoolo\Search\Dto\Search\Query\Facet\QueryFacet;
+use Atoolo\Search\Dto\Search\Query\Facet\RelativeDateRangeFacet;
+use Atoolo\Search\Dto\Search\Query\Facet\SiteFacet;
+use Atoolo\Search\Dto\Search\Query\Facet\SourceFacet;
+use Atoolo\Search\Dto\Search\Query\Facet\SpatialDistanceRangeFacet;
+use Atoolo\Search\Dto\Search\Query\Filter\AbsoluteDateRangeFilter;
+use Atoolo\Search\Dto\Search\Query\Filter\AndFilter;
+use Atoolo\Search\Dto\Search\Query\Filter\CategoryFilter;
+use Atoolo\Search\Dto\Search\Query\Filter\ContentSectionTypeFilter;
+use Atoolo\Search\Dto\Search\Query\Filter\ContentTypeFilter;
+use Atoolo\Search\Dto\Search\Query\Filter\GeoLocatedFilter;
+use Atoolo\Search\Dto\Search\Query\Filter\GroupFilter;
+use Atoolo\Search\Dto\Search\Query\Filter\IdFilter;
+use Atoolo\Search\Dto\Search\Query\Filter\NotFilter;
+use Atoolo\Search\Dto\Search\Query\Filter\ObjectTypeFilter;
+use Atoolo\Search\Dto\Search\Query\Filter\OrFilter;
+use Atoolo\Search\Dto\Search\Query\Filter\QueryFilter;
+use Atoolo\Search\Dto\Search\Query\Filter\RelativeDateRangeFilter;
+use Atoolo\Search\Dto\Search\Query\Filter\SiteFilter;
+use Atoolo\Search\Dto\Search\Query\Filter\SourceFilter;
+use Atoolo\Search\Dto\Search\Query\Filter\SpatialArbitraryRectangleFilter;
+use Atoolo\Search\Dto\Search\Query\Filter\SpatialOrbitalFilter;
+use Atoolo\Search\Dto\Search\Query\Filter\SpatialOrbitalMode;
+use Atoolo\Search\Dto\Search\Query\GeoPoint;
+use Atoolo\Search\Dto\Search\Query\QueryOperator;
+use Atoolo\Search\Dto\Search\Query\SearchQuery;
+use Atoolo\Search\Dto\Search\Query\SearchQueryBuilder;
+use Atoolo\Search\Dto\Search\Query\Sort\CustomField;
+use Atoolo\Search\Dto\Search\Query\Sort\Date;
+use Atoolo\Search\Dto\Search\Query\Sort\Direction;
+use Atoolo\Search\Dto\Search\Query\Sort\Name;
+use Atoolo\Search\Dto\Search\Query\Sort\Natural;
+use Atoolo\Search\Dto\Search\Query\Sort\Score;
+use Atoolo\Search\Dto\Search\Query\Sort\SpatialDist;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Atoolo\Search\Serializer\Search\Query\SearchQueryDenormalizer;
+use Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
+use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
+use Symfony\Component\Serializer\Normalizer\BackedEnumNormalizer;
+use Symfony\Component\Serializer\Normalizer\DateIntervalNormalizer;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+#[CoversClass(SearchQueryDenormalizer::class)]
+class SearchQueryDenormalizerTest extends TestCase
+{
+    private Serializer $serializer;
+
+    protected function setUp(): void
+    {
+        $encoders = [new JsonEncoder()];
+        $normalizers = [
+            new BackedEnumNormalizer(),
+            new ArrayDenormalizer(),
+            new SearchQueryDenormalizer(),
+            new DateTimeNormalizer(),
+            new DateIntervalNormalizer(),
+            new ObjectNormalizer(
+                new ClassMetadataFactory(new AttributeLoader()),
+                null,
+                null,
+                new PhpStanExtractor(),
+            ),
+        ];
+        $this->serializer = new Serializer($normalizers, $encoders);
+    }
+
+    public function testDenormalize(): void
+    {
+        $data =  [
+            'text' => 'TEXT',
+            'archive' => true,
+            'offset' => 100,
+            'limit' => 200,
+            'sort' => [
+                [
+                    'type' => 'customField',
+                    'field' => 'sp_custom_field',
+                    'direction' => 'DESC',
+                ],
+                [
+                    'type' => 'date',
+                    'direction' => 'ASC',
+                ],
+                [
+                    'type' => 'name',
+                    'direction' => 'ASC',
+                ],
+                [
+                    'type' => 'natural',
+                    'direction' => 'DESC',
+                ],
+                [
+                    'type' => 'score',
+                    'direction' => 'DESC',
+                ],
+                [
+                    'type' => 'spatialDist',
+                    'point' => [
+                        'lng' => 1.1,
+                        'lat' => 1.2,
+                    ],
+                    'direction' => 'ASC',
+                ],
+            ],
+            'boosting' => [
+                'boostFunctions' => ['a', 'b', 'c'],
+                'boostQueries' => ['d', 'e', 'f'],
+                'phraseFields' => ['g', 'h', 'i'],
+                'queryFields' => ['j', 'k', 'l'],
+                'tie' => 1337.0,
+            ],
+            'lang' => 'DE',
+            'timeZone' => 'Europe/Berlin',
+            'defaultQueryOperator' => 'AND',
+            'distanceReferencePoint' => [
+                'lng' => 0.2,
+                'lat' => 0.5,
+            ],
+            'facets' => [
+                [
+                    'type' => 'absoluteDateRange',
+                    'key' => 'absoluteDateRange',
+                    'from' => '10.02.2025',
+                    'to' => '11.02.2025',
+                    'gap' => 'P1D',
+                ],
+                [
+                    'type' => 'category',
+                    'key' => 'categories',
+                    'terms' => ['category1', 'category2'],
+                ],
+                [
+                    'type' => 'contentSectionType',
+                    'key' => 'contentSectionType',
+                    'terms' => ['contentSectionType1', 'contentSectionType2'],
+                ],
+                [
+                    'type' => 'contentType',
+                    'key' => 'contentType',
+                    'terms' => ['contentType1', 'contentType2'],
+                ],
+                [
+                    'type' => 'group',
+                    'key' => 'group',
+                    'terms' => ['group1', 'group2'],
+                ],
+                [
+                    'type' => 'multiQuery',
+                    'key' => 'multiQuery',
+                    'queries' => [
+                        [
+                            'type' => 'queryFacet',
+                            'key' => 'queryFacet1',
+                            'query' => 'some:query1',
+                        ],
+                        [
+                            'type' => 'queryFacet',
+                            'key' => 'queryFacet2',
+                            'query' => 'some:query2',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'objectType',
+                    'key' => 'objectType',
+                    'terms' => ['objectType1', 'objectType2'],
+                ],
+                [
+                    'type' => 'relativeDateRange',
+                    'key' => 'relativeDateRange',
+                    'base' => '10.02.2025',
+                    'before' => 'P2Y4DT6H8M',
+                    'after' => 'P32D',
+                    'gap' => 'P1D',
+                    'roundStart' => 'START_OF_DAY',
+                    'roundEnd' => 'END_OF_DAY',
+                ],
+                [
+                    'type' => 'site',
+                    'key' => 'site',
+                    'terms' => ['site1', 'site2'],
+                ],
+                [
+                    'type' => 'source',
+                    'key' => 'source',
+                    'terms' => ['source1', 'source2'],
+                ],
+                [
+                    'type' => 'spatialDistanceRange',
+                    'key' => 'spatialDistanceRange',
+                    'point' => [
+                        'lng' => 2.0,
+                        'lat' => 2.2,
+                    ],
+                    'from' => 4.0,
+                    'to' => 8.9,
+                ],
+
+            ],
+            'filter' => [
+                [
+                    'type' => 'group',
+                    'values' => ['group1', 'group2'],
+                ],
+                [
+                    'type' => 'and',
+                    'filter' => [
+                        [
+                            'type' => 'site',
+                            'values' => ['site1', 'site2'],
+                        ],
+                        [
+                            'type' => 'contentSectionType',
+                            'values' => ['contentSectionType1', 'contentSectionType2'],
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'or',
+                    'filter' => [
+                        [
+                            'type' => 'category',
+                            'values' => ['category1', 'category2'],
+                        ],
+                        [
+                            'type' => 'contentType',
+                            'values' => ['contentType1', 'contentType2'],
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'not',
+                    'filter' => [
+                        'type' => 'geoLocated',
+                        'exists' => true,
+                    ],
+                ],
+                [
+                    'type' => 'absoluteDateRange',
+                    'from' => '12.02.2025',
+                    'to' => '13.02.2025',
+                ],
+                [
+                    'type' => 'id',
+                    'values' => ['id1', 'id2'],
+                ],
+                [
+                    'type' => 'objectType',
+                    'values' => ['objectType1', 'objectType2'],
+                ],
+                [
+                    'type' => 'query',
+                    'query' => 'some:query',
+                ],
+                [
+                    'type' => 'relativeDateRange',
+                    'base' => '10.02.2025',
+                    'before' => 'P2Y4DT6H8M',
+                    'after' => 'P32D',
+                    'roundStart' => 'START_OF_DAY',
+                    'roundEnd' => 'END_OF_DAY',
+                ],
+                [
+                    'type' => 'source',
+                    'values' => ['source1', 'source2'],
+                ],
+                [
+                    'type' => 'spatialArbitraryRectangle',
+                    'lowerLeftCorner' => [
+                        'lng' => 1.1,
+                        'lat' => 4.4,
+                    ],
+                    'upperRightCorner' => [
+                        'lng' => 5.5,
+                        'lat' => 2.0,
+                    ],
+                ],
+                [
+                    'type' => 'spatialOrbital',
+                    'distance' => 3.3,
+                    'centerPoint' => [
+                        'lng' => 4.5,
+                        'lat' => 6.0,
+                    ],
+                    'mode' => 'bounding-box',
+                ],
+            ],
+            'explain' => false,
+        ];
+        /** @var ?SearchQuery $actual */
+        $actual = $this->serializer->denormalize($data, SearchQuery::class);
+        $expected = (new SearchQueryBuilder())
+            ->text('TEXT')
+            ->archive(true)
+            ->offset(100)
+            ->limit(200)
+            ->sort(
+                new CustomField('sp_custom_field', Direction::DESC),
+                new Date(Direction::ASC),
+                new Name(Direction::ASC),
+                new Natural(Direction::DESC),
+                new Score(Direction::DESC),
+                new SpatialDist(Direction::ASC, new GeoPoint(1.1, 1.2)),
+            )
+            ->boosting(
+                new Boosting(
+                    boostFunctions: ['a', 'b', 'c'],
+                    boostQueries: ['d', 'e', 'f'],
+                    phraseFields: ['g', 'h', 'i'],
+                    queryFields: ['j', 'k', 'l'],
+                    tie: 1337.0,
+                ),
+            )
+            ->lang(ResourceLanguage::of('DE'))
+            ->timeZone(new \DateTimeZone('Europe/Berlin'))
+            ->defaultQueryOperator(QueryOperator::AND)
+            ->facet(
+                new AbsoluteDateRangeFacet(
+                    'absoluteDateRange',
+                    new \DateTime('10.02.2025'),
+                    new \DateTime('11.02.2025'),
+                    new \DateInterval('P1D'),
+                ),
+                new CategoryFacet('categories', ['category1', 'category2']),
+                new ContentSectionTypeFacet('contentSectionType', ['contentSectionType1', 'contentSectionType2']),
+                new ContentTypeFacet('contentType', ['contentType1', 'contentType2']),
+                new GroupFacet('group', ['group1', 'group2']),
+                new MultiQueryFacet(
+                    'multiQuery',
+                    [
+                        new QueryFacet('queryFacet1', 'some:query1'),
+                        new QueryFacet('queryFacet2', 'some:query2'),
+                    ],
+                ),
+                new ObjectTypeFacet('objectType', ['objectType1', 'objectType2']),
+                new RelativeDateRangeFacet(
+                    'relativeDateRange',
+                    new \DateTime('10.02.2025'),
+                    new \DateInterval('P2Y4DT6H8M'),
+                    new \DateInterval('P32D'),
+                    new \DateInterval('P1D'),
+                    DateRangeRound::START_OF_DAY,
+                    DateRangeRound::END_OF_DAY,
+                ),
+                new SiteFacet('site', ['site1', 'site2']),
+                new SourceFacet('source', ['source1', 'source2']),
+                new SpatialDistanceRangeFacet(
+                    'spatialDistanceRange',
+                    new GeoPoint(2.0, 2.2),
+                    4.0,
+                    8.9,
+                ),
+            )
+            ->filter(
+                new GroupFilter(['group1', 'group2']),
+                new AndFilter([
+                    new SiteFilter(['site1', 'site2']),
+                    new ContentSectionTypeFilter(['contentSectionType1', 'contentSectionType2']),
+                ]),
+                new OrFilter([
+                    new CategoryFilter(['category1', 'category2']),
+                    new ContentTypeFilter(['contentType1', 'contentType2']),
+                ]),
+                new NotFilter(
+                    new GeoLocatedFilter(true),
+                ),
+                new AbsoluteDateRangeFilter(
+                    new \DateTime('12.02.2025'),
+                    new \DateTime('13.02.2025'),
+                ),
+                new IdFilter(['id1', 'id2']),
+                new ObjectTypeFilter(['objectType1', 'objectType2']),
+                new QueryFilter('some:query'),
+                new RelativeDateRangeFilter(
+                    new \DateTime('10.02.2025'),
+                    new \DateInterval('P2Y4DT6H8M'),
+                    new \DateInterval('P32D'),
+                    DateRangeRound::START_OF_DAY,
+                    DateRangeRound::END_OF_DAY,
+                ),
+                new SourceFilter(['source1', 'source2']),
+                new SpatialArbitraryRectangleFilter(
+                    new GeoPoint(1.1, 4.4),
+                    new GeoPoint(5.5, 2.0),
+                ),
+                new SpatialOrbitalFilter(
+                    3.3,
+                    new GeoPoint(4.5, 6.0),
+                    SpatialOrbitalMode::BOUNDING_BOX,
+                ),
+            )
+            ->distanceReferencePoint(new GeoPoint(0.2, 0.5))
+            ->build();
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testDenormalizeInvalid(): void
+    {
+        $this->expectException(NotNormalizableValueException::class);
+        $this->serializer->denormalize('invalid data', SearchQuery::class);
+    }
+}


### PR DESCRIPTION
- added class `SearchQueryDenormalizer` to denormalize search query data into a `SearchQuery` object.
- added `DiscriminatorMap` attributes to some abstract classes. This is needed for a `Serializer` to correctly resolve types.
- added backing strings to the sort direction enum `Direction`.
- added dev dependency `phpdocumentor/type-resolver`. This allows the use of a `PhpStanExtractor` in the `SearchQueryDenormalizerTest` class. 
