### PR TITLE
feat: added SearchQueryDenormalizer as tagged service

### DIFF
--- a/config/serializer.yaml
+++ b/config/serializer.yaml
@@ -1,0 +1,8 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+
+  Atoolo\Search\Serializer\Search\Query\SearchQueryDenormalizer:
+    tags:
+      - { name: 'serializer.normalizer' }

--- a/src/AtooloSearchBundle.php
+++ b/src/AtooloSearchBundle.php
@@ -33,5 +33,6 @@ class AtooloSearchBundle extends Bundle
         $loader->load('search.yaml');
         $loader->load('indexer.yaml');
         $loader->load('commands.yaml');
+        $loader->load('serializer.yaml');
     }
 }


### PR DESCRIPTION
Added SearchQueryDenormalizer as a service tagged with `serializer.normalizer`. This way it will be registered as a normalizer  for the default symfony serializer service (`@serializer`).