### PR TITLE
feat: read auth-groups from session to find protected resources

### DIFF
--- a/config/search.yaml
+++ b/config/search.yaml
@@ -66,6 +66,7 @@ services:
       - '@atoolo_search.solarium_client_factory'
       - '@atoolo_search.result_to_resource_resolver'
       - '@atoolo_search.field_mapper'
+      - '@request_stack'
       - !tagged_iterator atoolo_search.query_modifier
 
   atoolo_search.suggest:


### PR DESCRIPTION
Resources can be protected and are not found by default. For this purpose, `auth-groups` of the user's groups must be set in the PHP session, with which the user's rights are defined.