### PR TITLE
feat: teaser property filter

### DIFF
--- a/src/Dto/Search/Query/Filter/TeaserPropertyFilter.php
+++ b/src/Dto/Search/Query/Filter/TeaserPropertyFilter.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Search\Dto\Search\Query\Filter;
+
+/**
+ * @codeCoverageIgnore
+ */
+class TeaserPropertyFilter extends Filter
+{
+    public function __construct(
+        public readonly ?bool $image,
+        public readonly ?bool $imageCopyright,
+        public readonly ?bool $headline,
+        public readonly ?bool $text,
+        ?string $key = null,
+    ) {
+        parent::__construct(
+            $key,
+            $key !== null ? [$key] : [],
+        );
+    }
+}

--- a/src/Service/Search/Schema2xFieldMapper.php
+++ b/src/Service/Search/Schema2xFieldMapper.php
@@ -28,6 +28,7 @@ use Atoolo\Search\Dto\Search\Query\Filter\SiteFilter;
 use Atoolo\Search\Dto\Search\Query\Filter\SourceFilter;
 use Atoolo\Search\Dto\Search\Query\Filter\SpatialArbitraryRectangleFilter;
 use Atoolo\Search\Dto\Search\Query\Filter\SpatialOrbitalFilter;
+use Atoolo\Search\Dto\Search\Query\Filter\TeaserPropertyFilter;
 use Atoolo\Search\Dto\Search\Query\Sort\Criteria;
 use Atoolo\Search\Dto\Search\Query\Sort\CustomField;
 use Atoolo\Search\Dto\Search\Query\Sort\Date;
@@ -72,7 +73,7 @@ class Schema2xFieldMapper
         return match (true) {
             $filter instanceof IdFilter => 'id',
             $filter instanceof CategoryFilter => 'sp_category_path',
-            $filter instanceof ContentSectionTypeFilter => 'sp_contenttype',
+            $filter instanceof ContentSectionTypeFilter, $filter instanceof TeaserPropertyFilter => 'sp_contenttype',
             $filter instanceof GroupFilter => 'sp_group_path',
             $filter instanceof ObjectTypeFilter => 'sp_objecttype',
             $filter instanceof SiteFilter => 'sp_site',

--- a/test/Service/Search/SolrQueryFilterAppenderTest.php
+++ b/test/Service/Search/SolrQueryFilterAppenderTest.php
@@ -16,6 +16,7 @@ use Atoolo\Search\Dto\Search\Query\Filter\RelativeDateRangeFilter;
 use Atoolo\Search\Dto\Search\Query\Filter\SpatialArbitraryRectangleFilter;
 use Atoolo\Search\Dto\Search\Query\Filter\SpatialOrbitalFilter;
 use Atoolo\Search\Dto\Search\Query\Filter\SpatialOrbitalMode;
+use Atoolo\Search\Dto\Search\Query\Filter\TeaserPropertyFilter;
 use Atoolo\Search\Dto\Search\Query\GeoPoint;
 use Atoolo\Search\Service\Search\Schema2xFieldMapper;
 use Atoolo\Search\Service\Search\SolrQueryFilterAppender;
@@ -133,6 +134,39 @@ class SolrQueryFilterAppenderTest extends TestCase
 
         $this->appender->append($filter);
     }
+
+    public function testTeaserPropertyFilter(): void
+    {
+        $filter = new TeaserPropertyFilter(
+            image: true,
+            imageCopyright: false,
+            headline: true,
+            text: false,
+        );
+
+        $this->filterQuery->expects($this->once())
+            ->method('setQuery')
+            ->with('(test:teaserImage AND -test:teaserImageCopyright AND test:teaserHeadline AND -test:teaserText)');
+
+        $this->appender->append($filter);
+    }
+
+    public function testEmptyTeaserPropertyFilter(): void
+    {
+        $filter = new TeaserPropertyFilter(
+            image: null,
+            imageCopyright: null,
+            headline: null,
+            text: null,
+        );
+
+        $this->filterQuery->expects($this->once())
+            ->method('setQuery')
+            ->with('');
+
+        $this->appender->append($filter);
+    }
+
 
     public function testAbsoluteDateRangeFilterWithFromAndTo(): void
     {


### PR DESCRIPTION
This filter can be used to determine which properties a teaser must have so that its resource is included in the search result. For example, you can specify that a teaser must have an image.