### PR TITLE
feat: apply solr query modifiers after the query is build

### DIFF
--- a/src/Service/Search/SolrSearch.php
+++ b/src/Service/Search/SolrSearch.php
@@ -76,11 +76,6 @@ class SolrSearch implements Search
 
         $solrQuery = $client->createSelect();
 
-        // supplements the query with standard values, e.g. for boosting
-        foreach ($this->solrQueryModifierList as $solrQueryModifier) {
-            $solrQuery = $solrQueryModifier->modify($solrQuery);
-        }
-
         $solrQuery->setStart($query->offset);
         $solrQuery->setRows($query->limit);
 
@@ -117,6 +112,11 @@ class SolrSearch implements Search
 
         $this->addBoosting($solrQuery, $query->boosting);
         $this->addUserGroups($solrQuery);
+
+        // supplements the query with standard values, e.g. for boosting
+        foreach ($this->solrQueryModifierList as $solrQueryModifier) {
+            $solrQuery = $solrQueryModifier->modify($solrQuery);
+        }
 
         return $solrQuery;
     }

--- a/src/Service/Search/SolrSearch.php
+++ b/src/Service/Search/SolrSearch.php
@@ -113,7 +113,7 @@ class SolrSearch implements Search
         $this->addBoosting($solrQuery, $query->boosting);
         $this->addUserGroups($solrQuery);
 
-        // supplements the query with standard values, e.g. for boosting
+        // applying optional modifiers to search query, e.g. for adding return fields
         foreach ($this->solrQueryModifierList as $solrQueryModifier) {
             $solrQuery = $solrQueryModifier->modify($solrQuery);
         }


### PR DESCRIPTION
I think the solr query modifiers should be applied at the end of `buildSolrQuery`, shouldn't they?

Usecase: 
I want to add the additional return field `sp_date_to` in the project wiesbaden-lapwing. I think a custom query modifier would do the job, but since we call `setFields` in [this](https://github.com/sitepark/atoolo-search-bundle/blob/af123bbc6bc08523a0d521810d45c88b4a12a196/src/Service/Search/SolrSearch.php#L154) line instead of `addFields`, my modifiers would be overridden. 