### PR TITLE
feat: query template filter

### DIFF
--- a/config/search.yaml
+++ b/config/search.yaml
@@ -56,6 +56,9 @@ services:
   atoolo_search.field_mapper:
     class: Atoolo\Search\Service\Search\Schema2xFieldMapper
 
+  atoolo_search.query_template_resolver:
+    class: Atoolo\Search\Service\Search\QueryTemplateResolver
+
   atoolo_search.explain_builder:
     class: Atoolo\Search\Service\Search\SolrExplainBuilder
 
@@ -66,6 +69,7 @@ services:
       - '@atoolo_search.solarium_client_factory'
       - '@atoolo_search.result_to_resource_resolver'
       - '@atoolo_search.field_mapper'
+      - '@atoolo_search.query_template_resolver'
       - '@request_stack'
       - !tagged_iterator atoolo_search.query_modifier
 

--- a/src/Dto/Search/Query/Facet/QueryTemplateFacet.php
+++ b/src/Dto/Search/Query/Facet/QueryTemplateFacet.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Search\Dto\Search\Query\Facet;
+
+/**
+ * @codeCoverageIgnore
+ */
+class QueryTemplateFacet extends Facet
+{
+    /**
+     * @param array<string,mixed> $variables
+     * @param string[] $excludeFilter
+     */
+    public function __construct(
+        string $key,
+        public readonly string $query,
+        public readonly array $variables,
+        array $excludeFilter = [],
+    ) {
+        parent::__construct($key, $excludeFilter);
+    }
+}

--- a/src/Dto/Search/Query/Filter/QueryTemplateFilter.php
+++ b/src/Dto/Search/Query/Filter/QueryTemplateFilter.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Search\Dto\Search\Query\Filter;
+
+/**
+ * @codeCoverageIgnore
+ */
+class QueryTemplateFilter extends Filter
+{
+    /**
+     * @param array<string,mixed> $variables
+     */
+    public function __construct(
+        public readonly string $query,
+        public readonly array $variables,
+        ?string $key = null,
+    ) {
+        parent::__construct(
+            $key,
+        );
+    }
+}

--- a/src/Service/Search/QueryTemplateResolver.php
+++ b/src/Service/Search/QueryTemplateResolver.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Search\Service\Search;
+
+class QueryTemplateResolver
+{
+    /**
+     * @param array<string,mixed> $variables
+     */
+    public function resolve(string $query, array $variables): string
+    {
+        $placeholders = array_combine(
+            array_map(
+                static fn(string $key) => '{' . $key . '}',
+                array_keys($variables),
+            ),
+            array_values($variables),
+        );
+
+        return strtr($query, $placeholders);
+    }
+}

--- a/src/Service/Search/SolrMoreLikeThis.php
+++ b/src/Service/Search/SolrMoreLikeThis.php
@@ -25,6 +25,7 @@ class SolrMoreLikeThis implements MoreLikeThis
         private readonly SolrClientFactory $clientFactory,
         private readonly SolrResultToResourceResolver $resultToResourceResolver,
         private readonly Schema2xFieldMapper $schemaFieldMapper,
+        private readonly QueryTemplateResolver $queryTemplateResolver,
     ) {}
 
     public function moreLikeThis(MoreLikeThisQuery $query): SearchResult
@@ -69,6 +70,7 @@ class SolrMoreLikeThis implements MoreLikeThis
         $filterAppender = new SolrQueryFilterAppender(
             $solrQuery,
             $this->schemaFieldMapper,
+            $this->queryTemplateResolver,
         );
         foreach ($filterList as $filter) {
             $filterAppender->append($filter);

--- a/src/Service/Search/SolrSearch.php
+++ b/src/Service/Search/SolrSearch.php
@@ -54,6 +54,7 @@ class SolrSearch implements Search
         private readonly SolrClientFactory $clientFactory,
         private readonly SolrResultToResourceResolver $resourceResolver,
         private readonly Schema2xFieldMapper $schemaFieldMapper,
+        private readonly QueryTemplateResolver $queryTemplateResolver,
         private readonly RequestStack $requestStack,
         private readonly iterable $solrQueryModifierList = [],
     ) {}
@@ -229,6 +230,7 @@ class SolrSearch implements Search
         $filterAppender = new SolrQueryFilterAppender(
             $solrQuery,
             $this->schemaFieldMapper,
+            $this->queryTemplateResolver,
         );
         foreach ($filterList as $filter) {
             $filterAppender->append($filter);
@@ -263,6 +265,7 @@ class SolrSearch implements Search
         $facetAppender = new SolrQueryFacetAppender(
             $solrQuery,
             $this->schemaFieldMapper,
+            $this->queryTemplateResolver,
         );
         foreach ($facetList as $facet) {
             $facetAppender->append($facet);

--- a/src/Service/Search/SolrSuggest.php
+++ b/src/Service/Search/SolrSuggest.php
@@ -34,6 +34,7 @@ class SolrSuggest implements Suggest
         private readonly IndexName $index,
         private readonly SolrClientFactory $clientFactory,
         private readonly Schema2xFieldMapper $schemaFieldMapper,
+        private readonly QueryTemplateResolver $queryTemplateResolver,
     ) {}
 
     /**
@@ -94,6 +95,7 @@ class SolrSuggest implements Suggest
         $filterAppender = new SolrQueryFilterAppender(
             $solrQuery,
             $this->schemaFieldMapper,
+            $this->queryTemplateResolver,
         );
         foreach ($filterList as $filter) {
             $filterAppender->append($filter);

--- a/test/Console/Command/IndexerTest.php
+++ b/test/Console/Command/IndexerTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Atoolo\Search\Test\Console\Command;
 
+use Atoolo\Resource\Factory\ResourceChannelFactory;
 use Atoolo\Resource\ResourceChannel;
-use Atoolo\Resource\ResourceChannelFactory;
 use Atoolo\Resource\ResourceTenant;
 use Atoolo\Search\Console\Application;
 use Atoolo\Search\Console\Command\Indexer;

--- a/test/Service/Search/QueryTemplateResolverTest.php
+++ b/test/Service/Search/QueryTemplateResolverTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Search\Test\Service\Search;
+
+use Atoolo\Search\Service\Search\QueryTemplateResolver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(QueryTemplateResolver::class)]
+class QueryTemplateResolverTest extends TestCase
+{
+    public function testResolveWithValidVariables(): void
+    {
+        $resolver = new QueryTemplateResolver();
+        $query = 'myfield:{myvar}';
+        $variables = ['myvar' => 'myvalue'];
+
+        $this->assertSame('myfield:myvalue', $resolver->resolve($query, $variables));
+    }
+}

--- a/test/Service/Search/SolrMoreLikeThisTest.php
+++ b/test/Service/Search/SolrMoreLikeThisTest.php
@@ -9,6 +9,7 @@ use Atoolo\Resource\ResourceLanguage;
 use Atoolo\Search\Dto\Search\Query\Filter\ObjectTypeFilter;
 use Atoolo\Search\Dto\Search\Query\MoreLikeThisQuery;
 use Atoolo\Search\Service\IndexName;
+use Atoolo\Search\Service\Search\QueryTemplateResolver;
 use Atoolo\Search\Service\Search\Schema2xFieldMapper;
 use Atoolo\Search\Service\Search\SolrMoreLikeThis;
 use Atoolo\Search\Service\Search\SolrResultToResourceResolver;
@@ -58,12 +59,16 @@ class SolrMoreLikeThisTest extends TestCase
         $schemaFieldMapper = $this->createStub(
             Schema2xFieldMapper::class,
         );
+        $queryTemplateResolver = $this->createStub(
+            QueryTemplateResolver::class,
+        );
 
         $this->searcher = new SolrMoreLikeThis(
             $indexName,
             $clientFactory,
             $resultToResourceResolver,
             $schemaFieldMapper,
+            $queryTemplateResolver,
         );
     }
 

--- a/test/Service/Search/SolrQueryFacetAppenderTest.php
+++ b/test/Service/Search/SolrQueryFacetAppenderTest.php
@@ -9,9 +9,11 @@ use Atoolo\Search\Dto\Search\Query\Facet\Facet;
 use Atoolo\Search\Dto\Search\Query\Facet\MultiQueryFacet;
 use Atoolo\Search\Dto\Search\Query\Facet\ObjectTypeFacet;
 use Atoolo\Search\Dto\Search\Query\Facet\QueryFacet;
+use Atoolo\Search\Dto\Search\Query\Facet\QueryTemplateFacet;
 use Atoolo\Search\Dto\Search\Query\Facet\RelativeDateRangeFacet;
 use Atoolo\Search\Dto\Search\Query\Facet\SpatialDistanceRangeFacet;
 use Atoolo\Search\Dto\Search\Query\GeoPoint;
+use Atoolo\Search\Service\Search\QueryTemplateResolver;
 use Atoolo\Search\Service\Search\Schema2xFieldMapper;
 use Atoolo\Search\Service\Search\SolrQueryFacetAppender;
 use DateInterval;
@@ -74,7 +76,10 @@ class SolrQueryFacetAppenderTest extends TestCase
         $fieldMapper = $this->createMock(Schema2xFieldMapper::class);
         $fieldMapper->method('getFacetField')
             ->willReturn('test');
-        $this->appender = new SolrQueryFacetAppender($solrQuery, $fieldMapper);
+
+        $queryTemplateResolver = new QueryTemplateResolver();
+
+        $this->appender = new SolrQueryFacetAppender($solrQuery, $fieldMapper, $queryTemplateResolver);
     }
 
     public function testAppendFieldFacet(): void
@@ -117,6 +122,17 @@ class SolrQueryFacetAppenderTest extends TestCase
                 ['exclude'],
             ),
         );
+    }
+
+    public function testAppendQueryTemplateFacet(): void
+    {
+        $this->facetQuery->expects($this->once())
+            ->method('setQuery')
+            ->with('myfield:myvalue');
+        $this->facetQuery->expects($this->once())
+            ->method('setExcludes')
+            ->with(['exclude']);
+        $this->appender->append(new QueryTemplateFacet('key', 'myfield:{myvar}', ['myvar' => 'myvalue'], ['exclude']));
     }
 
     public function testAppendAbsoluteDateRangeFacetWithOutGap(): void

--- a/test/Service/Search/SolrQueryFilterAppenderTest.php
+++ b/test/Service/Search/SolrQueryFilterAppenderTest.php
@@ -12,12 +12,14 @@ use Atoolo\Search\Dto\Search\Query\Filter\GeoLocatedFilter;
 use Atoolo\Search\Dto\Search\Query\Filter\NotFilter;
 use Atoolo\Search\Dto\Search\Query\Filter\OrFilter;
 use Atoolo\Search\Dto\Search\Query\Filter\QueryFilter;
+use Atoolo\Search\Dto\Search\Query\Filter\QueryTemplateFilter;
 use Atoolo\Search\Dto\Search\Query\Filter\RelativeDateRangeFilter;
 use Atoolo\Search\Dto\Search\Query\Filter\SpatialArbitraryRectangleFilter;
 use Atoolo\Search\Dto\Search\Query\Filter\SpatialOrbitalFilter;
 use Atoolo\Search\Dto\Search\Query\Filter\SpatialOrbitalMode;
 use Atoolo\Search\Dto\Search\Query\Filter\TeaserPropertyFilter;
 use Atoolo\Search\Dto\Search\Query\GeoPoint;
+use Atoolo\Search\Service\Search\QueryTemplateResolver;
 use Atoolo\Search\Service\Search\Schema2xFieldMapper;
 use Atoolo\Search\Service\Search\SolrQueryFilterAppender;
 use DateInterval;
@@ -49,7 +51,9 @@ class SolrQueryFilterAppenderTest extends TestCase
             ->willReturn('test');
         $fieldMapper->method('getArchiveField')
             ->willReturn('archive');
-        $this->appender = new SolrQueryFilterAppender($solrQuery, $fieldMapper);
+        $queryTemplateResolver = new QueryTemplateResolver();
+
+        $this->appender = new SolrQueryFilterAppender($solrQuery, $fieldMapper, $queryTemplateResolver);
     }
 
     public function testExcludeArchived(): void
@@ -142,6 +146,17 @@ class SolrQueryFilterAppenderTest extends TestCase
         $this->filterQuery->expects($this->once())
             ->method('setQuery')
             ->with('a:b');
+
+        $this->appender->append($filter);
+    }
+
+    public function testQueryTemplateFilter(): void
+    {
+        $filter = new QueryTemplateFilter('myfield:{myvar}', ['myvar' => 'myvalue']);
+
+        $this->filterQuery->expects($this->once())
+            ->method('setQuery')
+            ->with('myfield:myvalue');
 
         $this->appender->append($filter);
     }

--- a/test/Service/Search/SolrSearchTest.php
+++ b/test/Service/Search/SolrSearchTest.php
@@ -23,6 +23,7 @@ use Atoolo\Search\Dto\Search\Result\Spellcheck;
 use Atoolo\Search\Dto\Search\Result\SpellcheckSuggestion;
 use Atoolo\Search\Dto\Search\Result\SpellcheckWord;
 use Atoolo\Search\Service\IndexName;
+use Atoolo\Search\Service\Search\QueryTemplateResolver;
 use Atoolo\Search\Service\Search\Schema2xFieldMapper;
 use Atoolo\Search\Service\Search\SolrQueryModifier;
 use Atoolo\Search\Service\Search\SolrResultToResourceResolver;
@@ -100,6 +101,8 @@ class SolrSearchTest extends TestCase
         );
         $schemaFieldMapper->method('getGeoPointField')->willReturn('geo_points');
 
+        $queryTemplateResolver = $this->createStub(QueryTemplateResolver::class);
+
         $this->requestStack = $this->createStub(RequestStack::class);
 
         $this->searcher = new SolrSearch(
@@ -107,6 +110,7 @@ class SolrSearchTest extends TestCase
             $clientFactory,
             $resultToResourceResolver,
             $schemaFieldMapper,
+            $queryTemplateResolver,
             $this->requestStack,
             [$solrQueryModifier],
         );

--- a/test/Service/Search/SolrSuggestTest.php
+++ b/test/Service/Search/SolrSuggestTest.php
@@ -10,10 +10,12 @@ use Atoolo\Search\Dto\Search\Query\SuggestQuery;
 use Atoolo\Search\Dto\Search\Result\Suggestion;
 use Atoolo\Search\Exception\UnexpectedResultException;
 use Atoolo\Search\Service\IndexName;
+use Atoolo\Search\Service\Search\QueryTemplateResolver;
 use Atoolo\Search\Service\Search\Schema2xFieldMapper;
 use Atoolo\Search\Service\Search\SolrSuggest;
 use Atoolo\Search\Service\SolrClientFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Solarium\Client;
@@ -29,6 +31,9 @@ class SolrSuggestTest extends TestCase
 
     private SolrSuggest $searcher;
 
+    /**
+     * @throws Exception
+     */
     protected function setUp(): void
     {
         $indexName = $this->createStub(IndexName::class);
@@ -48,14 +53,15 @@ class SolrSuggestTest extends TestCase
         $this->result = $this->createStub(SelectResult::class);
         $client->method('select')->willReturn($this->result);
 
-        $schemaFieldMapper = $this->createStub(
-            Schema2xFieldMapper::class,
-        );
+        $schemaFieldMapper = $this->createStub(Schema2xFieldMapper::class);
+
+        $queryTemplateResolver = $this->createStub(QueryTemplateResolver::class);
 
         $this->searcher = new SolrSuggest(
             $indexName,
             $clientFactory,
             $schemaFieldMapper,
+            $queryTemplateResolver,
         );
     }
 


### PR DESCRIPTION
Search filters are not only created directly by the frontend but are also transferred to the frontend via HTML data attributes. These preconfigured filters are then activated on the frontend page by user actions with certain attributes. There may be query filters that should not be assembled by the frontend first. The QueryTemplateFilter is used for these cases. Here, the query can be predefined with placeholders. And the frontend only needs to set the variables.