### PR TITLE
feat: added directional date intervals for relative date range filter/facet

### DIFF
--- a/src/Dto/Search/Query/DateIntervalDirection.php
+++ b/src/Dto/Search/Query/DateIntervalDirection.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Search\Dto\Search\Query;
+
+/**
+ * @codeCoverageIgnore
+ */
+enum DateIntervalDirection: string
+{
+    case PAST = 'PAST';
+    case FUTURE = 'FUTURE';
+}

--- a/src/Dto/Search/Query/DirectedDateInterval.php
+++ b/src/Dto/Search/Query/DirectedDateInterval.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Search\Dto\Search\Query;
+
+use DateInterval;
+
+/**
+ * @codeCoverageIgnore
+ */
+class DirectedDateInterval
+{
+    public function __construct(
+        public readonly DateInterval $interval,
+        public readonly DateIntervalDirection $direction = DateIntervalDirection::FUTURE,
+    ) {}
+}

--- a/src/Dto/Search/Query/Facet/RelativeDateRangeFacet.php
+++ b/src/Dto/Search/Query/Facet/RelativeDateRangeFacet.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atoolo\Search\Dto\Search\Query\Facet;
 
 use Atoolo\Search\Dto\Search\Query\DateRangeRound;
+use Atoolo\Search\Dto\Search\Query\DirectedDateInterval;
 use DateInterval;
 
 /**
@@ -13,16 +14,18 @@ use DateInterval;
 class RelativeDateRangeFacet extends Facet
 {
     /**
+     * @param DateInterval|DirectedDateInterval|null $before
+     * @param DateInterval|DirectedDateInterval|null $after
      * @param string[] $excludeFilter
      */
     public function __construct(
         string $key,
-        public readonly ?\DateTime $base,
-        public readonly ?DateInterval $before,
-        public readonly ?DateInterval $after,
-        public readonly ?DateInterval $gap,
-        public readonly ?DateRangeRound $roundStart,
-        public readonly ?DateRangeRound $roundEnd,
+        public readonly ?\DateTime $base = null,
+        public readonly mixed $before = null,
+        public readonly mixed $after = null,
+        public readonly ?DateInterval $gap = null,
+        public readonly ?DateRangeRound $roundStart = null,
+        public readonly ?DateRangeRound $roundEnd = null,
         array $excludeFilter = [],
     ) {
         parent::__construct(

--- a/src/Dto/Search/Query/Filter/RelativeDateRangeFilter.php
+++ b/src/Dto/Search/Query/Filter/RelativeDateRangeFilter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atoolo\Search\Dto\Search\Query\Filter;
 
 use Atoolo\Search\Dto\Search\Query\DateRangeRound;
+use Atoolo\Search\Dto\Search\Query\DirectedDateInterval;
 use DateInterval;
 use DateTime;
 
@@ -13,12 +14,16 @@ use DateTime;
  */
 class RelativeDateRangeFilter extends Filter
 {
+    /**
+     * @param DateInterval|DirectedDateInterval|null $before
+     * @param DateInterval|DirectedDateInterval|null $after
+     */
     public function __construct(
-        public readonly ?DateTime $base,
-        public readonly ?DateInterval $before,
-        public readonly ?DateInterval $after,
-        public readonly ?DateRangeRound $roundStart,
-        public readonly ?DateRangeRound $roundEnd,
+        public readonly ?DateTime $base = null,
+        public readonly mixed $before = null,
+        public readonly mixed $after = null,
+        public readonly ?DateRangeRound $roundStart = null,
+        public readonly ?DateRangeRound $roundEnd = null,
         ?string $key = null,
     ) {
         parent::__construct(

--- a/src/Service/Search/SolrQueryFilterAppender.php
+++ b/src/Service/Search/SolrQueryFilterAppender.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Atoolo\Search\Service\Search;
 
+use Atoolo\Search\Dto\Search\Query\DateIntervalDirection;
+use Atoolo\Search\Dto\Search\Query\DirectedDateInterval;
 use Atoolo\Search\Dto\Search\Query\Filter\AbsoluteDateRangeFilter;
 use Atoolo\Search\Dto\Search\Query\Filter\AndFilter;
 use Atoolo\Search\Dto\Search\Query\Filter\FieldFilter;
@@ -18,6 +20,7 @@ use Atoolo\Search\Dto\Search\Query\Filter\SpatialArbitraryRectangleFilter;
 use Atoolo\Search\Dto\Search\Query\Filter\SpatialOrbitalFilter;
 use Atoolo\Search\Dto\Search\Query\Filter\SpatialOrbitalMode;
 use Atoolo\Search\Dto\Search\Query\Filter\TeaserPropertyFilter;
+use DateInterval;
 use InvalidArgumentException;
 use Solarium\QueryType\Select\Query\Query as SolrSelectQuery;
 
@@ -164,9 +167,15 @@ class SolrQueryFilterAppender
                 $filter->roundStart,
             );
         } else {
+            $directedInterval = $filter->before instanceof DateInterval
+                ? new DirectedDateInterval($filter->before, DateIntervalDirection::PAST)
+                : $filter->before;
             $from = SolrDateMapper::roundStart(
                 SolrDateMapper::mapDateTime($filter->base) .
-                SolrDateMapper::mapDateInterval($filter->before, '-'),
+                    SolrDateMapper::mapDateInterval(
+                        $directedInterval->interval,
+                        $directedInterval->direction === DateIntervalDirection::FUTURE ? '+' : '-',
+                    ),
                 $filter->roundStart,
             );
         }
@@ -177,9 +186,15 @@ class SolrQueryFilterAppender
                 $filter->roundEnd,
             );
         } else {
+            $directedInterval = $filter->after instanceof DateInterval
+                ? new DirectedDateInterval($filter->after, DateIntervalDirection::FUTURE)
+                : $filter->after;
             $to = SolrDateMapper::roundEnd(
                 SolrDateMapper::mapDateTime($filter->base) .
-                SolrDateMapper::mapDateInterval($filter->after, '+'),
+                    SolrDateMapper::mapDateInterval(
+                        $directedInterval->interval,
+                        $directedInterval->direction === DateIntervalDirection::FUTURE ? '+' : '-',
+                    ),
                 $filter->roundEnd,
             );
         }

--- a/test/Serializer/Search/Query/SearchQueryDenormalizerTest.php
+++ b/test/Serializer/Search/Query/SearchQueryDenormalizerTest.php
@@ -6,7 +6,9 @@ namespace Atoolo\Search\Test\Serializer\Search\Query;
 
 use Atoolo\Resource\ResourceLanguage;
 use Atoolo\Search\Dto\Search\Query\Boosting;
+use Atoolo\Search\Dto\Search\Query\DateIntervalDirection;
 use Atoolo\Search\Dto\Search\Query\DateRangeRound;
+use Atoolo\Search\Dto\Search\Query\DirectedDateInterval;
 use Atoolo\Search\Dto\Search\Query\Facet\AbsoluteDateRangeFacet;
 use Atoolo\Search\Dto\Search\Query\Facet\CategoryFacet;
 use Atoolo\Search\Dto\Search\Query\Facet\ContentSectionTypeFacet;
@@ -51,6 +53,7 @@ use Atoolo\Search\Dto\Search\Query\Sort\SpatialDist;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Atoolo\Search\Serializer\Search\Query\SearchQueryDenormalizer;
+use DateInterval;
 use Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
@@ -190,10 +193,26 @@ class SearchQueryDenormalizerTest extends TestCase
                 ],
                 [
                     'type' => 'relativeDateRange',
-                    'key' => 'relativeDateRange',
+                    'key' => 'relativeDateRange-1',
                     'base' => '10.02.2025',
                     'before' => 'P2Y4DT6H8M',
                     'after' => 'P32D',
+                    'gap' => 'P1D',
+                    'roundStart' => 'START_OF_DAY',
+                    'roundEnd' => 'END_OF_DAY',
+                ],
+                [
+                    'type' => 'relativeDateRange',
+                    'key' => 'relativeDateRange-2',
+                    'base' => '10.02.2025',
+                    'before' => [
+                        'interval' => 'P2Y4DT6H8M',
+                        'direction' => 'PAST',
+                    ],
+                    'after' => [
+                        'interval' => 'P32D',
+                        'direction' => 'FUTURE',
+                    ],
                     'gap' => 'P1D',
                     'roundStart' => 'START_OF_DAY',
                     'roundEnd' => 'END_OF_DAY',
@@ -284,6 +303,20 @@ class SearchQueryDenormalizerTest extends TestCase
                     'roundEnd' => 'END_OF_DAY',
                 ],
                 [
+                    'type' => 'relativeDateRange',
+                    'base' => '10.02.2025',
+                    'before' => [
+                        'interval' => 'P2Y4DT6H8M',
+                        'direction' => 'PAST',
+                    ],
+                    'after' => [
+                        'interval' => 'P32D',
+                        'direction' => 'FUTURE',
+                    ],
+                    'roundStart' => 'START_OF_DAY',
+                    'roundEnd' => 'END_OF_DAY',
+                ],
+                [
                     'type' => 'source',
                     'values' => ['source1', 'source2'],
                 ],
@@ -357,10 +390,19 @@ class SearchQueryDenormalizerTest extends TestCase
                 ),
                 new ObjectTypeFacet('objectType', ['objectType1', 'objectType2']),
                 new RelativeDateRangeFacet(
-                    'relativeDateRange',
+                    'relativeDateRange-1',
                     new \DateTime('10.02.2025'),
                     new \DateInterval('P2Y4DT6H8M'),
                     new \DateInterval('P32D'),
+                    new \DateInterval('P1D'),
+                    DateRangeRound::START_OF_DAY,
+                    DateRangeRound::END_OF_DAY,
+                ),
+                new RelativeDateRangeFacet(
+                    'relativeDateRange-2',
+                    new \DateTime('10.02.2025'),
+                    new DirectedDateInterval(new \DateInterval('P2Y4DT6H8M'), DateIntervalDirection::PAST),
+                    new DirectedDateInterval(new \DateInterval('P32D'), DateIntervalDirection::FUTURE),
                     new \DateInterval('P1D'),
                     DateRangeRound::START_OF_DAY,
                     DateRangeRound::END_OF_DAY,
@@ -398,6 +440,13 @@ class SearchQueryDenormalizerTest extends TestCase
                     new \DateTime('10.02.2025'),
                     new \DateInterval('P2Y4DT6H8M'),
                     new \DateInterval('P32D'),
+                    DateRangeRound::START_OF_DAY,
+                    DateRangeRound::END_OF_DAY,
+                ),
+                new RelativeDateRangeFilter(
+                    new \DateTime('10.02.2025'),
+                    new DirectedDateInterval(new \DateInterval('P2Y4DT6H8M'), DateIntervalDirection::PAST),
+                    new DirectedDateInterval(new \DateInterval('P32D'), DateIntervalDirection::FUTURE),
                     DateRangeRound::START_OF_DAY,
                     DateRangeRound::END_OF_DAY,
                 ),


### PR DESCRIPTION
Currently, it's not possible to define a `RelativeDateRangeFilter` where the lower and upper date boundaries _both_ lie in the past/future.
Possible: "From NOW-1MONTH to NOW+2MONTH"
Not possible:  "From NOW+1MONTH to NOW+2MONTH" or "From NOW-2MONTH to NOW-1MONTH"

This is because `DateInterval $before`, which defines the from-date, implicitly has the operator "-", and `DateInterval $after`, which defines the to-date, implicitly has the operator "+". 

The same goes for the `RelativeDateRangeFacet`.

To solve this, I introduced a `DirectedDateInterval` that has two properties: A `DateInterval` and a `DateIntervalDirection`.
I modified the `RelativeDateRangeFilter` and `RelativeDateRangeFacet` to handle both normal `DateInterval` objects as well as `DirectedDateInterval` objects.

That said, I also think that the property names "before" and "after" are a little confusing. I would suggest to rename them in the future, maybe to "startOffset" and "endOffset". 