### PR TITLE
feat: added fields "from" and "to" to relative date range filter/facet

### DIFF
--- a/src/Dto/Search/Query/Facet/RelativeDateRangeFacet.php
+++ b/src/Dto/Search/Query/Facet/RelativeDateRangeFacet.php
@@ -41,12 +41,12 @@ class RelativeDateRangeFacet extends Facet
         $this->after = $after;
         if ($this->before !== null && $this->from !== null) {
             throw new \InvalidArgumentException(
-                'Cannot use both the deprecated "before" and new "from" arguments. Please use only "from".'
+                'Cannot use both the deprecated "before" and new "from" arguments. Please use only "from".',
             );
         }
         if ($this->after !== null && $this->to !== null) {
             throw new \InvalidArgumentException(
-                'Cannot use both the deprecated "after" and new "to" arguments. Please use only "to".'
+                'Cannot use both the deprecated "after" and new "to" arguments. Please use only "to".',
             );
         }
         parent::__construct(

--- a/src/Dto/Search/Query/Facet/RelativeDateRangeFacet.php
+++ b/src/Dto/Search/Query/Facet/RelativeDateRangeFacet.php
@@ -13,18 +13,32 @@ use DateInterval;
 class RelativeDateRangeFacet extends Facet
 {
     /**
+     * @deprecated use property `$from` instead
+     */
+    public readonly ?DateInterval $before;
+
+    /**
+     * @deprecated use property `$to` instead
+     */
+    public readonly ?DateInterval $after;
+
+    /**
      * @param string[] $excludeFilter
      */
     public function __construct(
         string $key,
-        public readonly ?\DateTime $base,
-        public readonly ?DateInterval $before,
-        public readonly ?DateInterval $after,
-        public readonly ?DateInterval $gap,
-        public readonly ?DateRangeRound $roundStart,
-        public readonly ?DateRangeRound $roundEnd,
+        public readonly ?\DateTime $base = null,
+        ?DateInterval $before = null,
+        ?DateInterval $after = null,
+        public readonly ?DateInterval $gap = null,
+        public readonly ?DateRangeRound $roundStart = null,
+        public readonly ?DateRangeRound $roundEnd = null,
         array $excludeFilter = [],
+        public readonly ?DateInterval $from = null,
+        public readonly ?DateInterval $to = null,
     ) {
+        $this->before = $before;
+        $this->after = $after;
         parent::__construct(
             $key,
             $excludeFilter,

--- a/src/Dto/Search/Query/Facet/RelativeDateRangeFacet.php
+++ b/src/Dto/Search/Query/Facet/RelativeDateRangeFacet.php
@@ -39,6 +39,16 @@ class RelativeDateRangeFacet extends Facet
     ) {
         $this->before = $before;
         $this->after = $after;
+        if ($this->before !== null && $this->from !== null) {
+            throw new \InvalidArgumentException(
+                'Cannot use both the deprecated "before" and new "from" arguments. Please use only "from".'
+            );
+        }
+        if ($this->after !== null && $this->to !== null) {
+            throw new \InvalidArgumentException(
+                'Cannot use both the deprecated "after" and new "to" arguments. Please use only "to".'
+            );
+        }
         parent::__construct(
             $key,
             $excludeFilter,

--- a/src/Dto/Search/Query/Facet/RelativeDateRangeFacet.php
+++ b/src/Dto/Search/Query/Facet/RelativeDateRangeFacet.php
@@ -22,6 +22,10 @@ class RelativeDateRangeFacet extends Facet
      */
     public readonly ?DateInterval $after;
 
+    public readonly ?DateInterval $from;
+
+    public readonly ?DateInterval $to;
+
     /**
      * @param string[] $excludeFilter
      */
@@ -34,20 +38,27 @@ class RelativeDateRangeFacet extends Facet
         public readonly ?DateRangeRound $roundStart = null,
         public readonly ?DateRangeRound $roundEnd = null,
         array $excludeFilter = [],
-        public readonly ?DateInterval $from = null,
-        public readonly ?DateInterval $to = null,
+        ?DateInterval $from = null,
+        ?DateInterval $to = null,
     ) {
-        $this->before = $before;
-        $this->after = $after;
-        if ($this->before !== null && $this->from !== null) {
+        if ($before !== null && $from !== null) {
             throw new \InvalidArgumentException(
                 'Cannot use both the deprecated "before" and new "from" arguments. Please use only "from".',
             );
         }
-        if ($this->after !== null && $this->to !== null) {
+        if ($after !== null && $to !== null) {
             throw new \InvalidArgumentException(
                 'Cannot use both the deprecated "after" and new "to" arguments. Please use only "to".',
             );
+        }
+        $this->before = $before;
+        $this->after = $after;
+        $this->to = $to ?? $after;
+        if ($from === null && $before !== null) {
+            $this->from = clone $before;
+            $this->from->invert = $this->from->invert === 1 ? 0 : 1;
+        } else {
+            $this->from = $from;
         }
         parent::__construct(
             $key,

--- a/src/Dto/Search/Query/Filter/RelativeDateRangeFilter.php
+++ b/src/Dto/Search/Query/Filter/RelativeDateRangeFilter.php
@@ -23,6 +23,10 @@ class RelativeDateRangeFilter extends Filter
      */
     public readonly ?DateInterval $after;
 
+    public readonly ?DateInterval $from;
+
+    public readonly ?DateInterval $to;
+
     public function __construct(
         public readonly ?DateTime $base = null,
         ?DateInterval $before = null,
@@ -30,20 +34,27 @@ class RelativeDateRangeFilter extends Filter
         public readonly ?DateRangeRound $roundStart = null,
         public readonly ?DateRangeRound $roundEnd = null,
         ?string $key = null,
-        public readonly ?DateInterval $from = null,
-        public readonly ?DateInterval $to = null,
+        ?DateInterval $from = null,
+        ?DateInterval $to = null,
     ) {
-        $this->before = $before;
-        $this->after = $after;
-        if ($this->before !== null && $this->from !== null) {
+        if ($before !== null && $from !== null) {
             throw new \InvalidArgumentException(
                 'Cannot use both the deprecated "before" and new "from" arguments. Please use only "from".',
             );
         }
-        if ($this->after !== null && $this->to !== null) {
+        if ($after !== null && $to !== null) {
             throw new \InvalidArgumentException(
                 'Cannot use both the deprecated "after" and new "to" arguments. Please use only "to".',
             );
+        }
+        $this->before = $before;
+        $this->after = $after;
+        $this->to = $to ?? $after;
+        if ($from === null && $before !== null) {
+            $this->from = clone $before;
+            $this->from->invert = $this->from->invert === 1 ? 0 : 1;
+        } else {
+            $this->from = $from;
         }
         parent::__construct(
             $key,

--- a/src/Dto/Search/Query/Filter/RelativeDateRangeFilter.php
+++ b/src/Dto/Search/Query/Filter/RelativeDateRangeFilter.php
@@ -35,6 +35,16 @@ class RelativeDateRangeFilter extends Filter
     ) {
         $this->before = $before;
         $this->after = $after;
+        if ($this->before !== null && $this->from !== null) {
+            throw new \InvalidArgumentException(
+                'Cannot use both the deprecated "before" and new "from" arguments. Please use only "from".'
+            );
+        }
+        if ($this->after !== null && $this->to !== null) {
+            throw new \InvalidArgumentException(
+                'Cannot use both the deprecated "after" and new "to" arguments. Please use only "to".'
+            );
+        }
         parent::__construct(
             $key,
             $key !== null ? [$key] : [],

--- a/src/Dto/Search/Query/Filter/RelativeDateRangeFilter.php
+++ b/src/Dto/Search/Query/Filter/RelativeDateRangeFilter.php
@@ -13,14 +13,28 @@ use DateTime;
  */
 class RelativeDateRangeFilter extends Filter
 {
+    /**
+     * @deprecated use property `$from` instead
+     */
+    public readonly ?DateInterval $before;
+
+    /**
+     * @deprecated use property `$to` instead
+     */
+    public readonly ?DateInterval $after;
+
     public function __construct(
-        public readonly ?DateTime $base,
-        public readonly ?DateInterval $before,
-        public readonly ?DateInterval $after,
-        public readonly ?DateRangeRound $roundStart,
-        public readonly ?DateRangeRound $roundEnd,
+        public readonly ?DateTime $base = null,
+        ?DateInterval $before = null,
+        ?DateInterval $after = null,
+        public readonly ?DateRangeRound $roundStart = null,
+        public readonly ?DateRangeRound $roundEnd = null,
         ?string $key = null,
+        public readonly ?DateInterval $from = null,
+        public readonly ?DateInterval $to = null,
     ) {
+        $this->before = $before;
+        $this->after = $after;
         parent::__construct(
             $key,
             $key !== null ? [$key] : [],

--- a/src/Dto/Search/Query/Filter/RelativeDateRangeFilter.php
+++ b/src/Dto/Search/Query/Filter/RelativeDateRangeFilter.php
@@ -37,12 +37,12 @@ class RelativeDateRangeFilter extends Filter
         $this->after = $after;
         if ($this->before !== null && $this->from !== null) {
             throw new \InvalidArgumentException(
-                'Cannot use both the deprecated "before" and new "from" arguments. Please use only "from".'
+                'Cannot use both the deprecated "before" and new "from" arguments. Please use only "from".',
             );
         }
         if ($this->after !== null && $this->to !== null) {
             throw new \InvalidArgumentException(
-                'Cannot use both the deprecated "after" and new "to" arguments. Please use only "to".'
+                'Cannot use both the deprecated "after" and new "to" arguments. Please use only "to".',
             );
         }
         parent::__construct(

--- a/src/Service/Search/SolrQueryFacetAppender.php
+++ b/src/Service/Search/SolrQueryFacetAppender.php
@@ -140,12 +140,7 @@ class SolrQueryFacetAppender
     private function appendRelativeDateRangeFacet(
         RelativeDateRangeFacet $facet,
     ): void {
-        $lowerBoundary = $facet->from;
-        if ($lowerBoundary === null && $facet->before !== null) {
-            $lowerBoundary = clone $facet->before;
-            $lowerBoundary->invert = 1; // before is always inverted
-        }
-        $start = $lowerBoundary === null
+        $start = $facet->from === null
             ? SolrDateMapper::roundStart(
                 SolrDateMapper::mapDateTime($facet->base),
                 $facet->roundStart,
@@ -153,18 +148,12 @@ class SolrQueryFacetAppender
             : SolrDateMapper::roundStart(
                 SolrDateMapper::mapDateTime($facet->base) .
                     SolrDateMapper::mapDateInterval(
-                        $lowerBoundary,
-                        $lowerBoundary->invert === 1 ? '-' : '+',
+                        $facet->from,
+                        $facet->from->invert === 1 ? '-' : '+',
                     ),
                 $facet->roundStart,
             );
-
-        $upperBoundary = $facet->to;
-        if ($upperBoundary === null && $facet->after !== null) {
-            $upperBoundary = clone $facet->after;
-            $upperBoundary->invert = 0; // after is always not inverted
-        }
-        $end = $upperBoundary === null
+        $end = $facet->to === null
             ? SolrDateMapper::roundEnd(
                 SolrDateMapper::mapDateTime($facet->base),
                 $facet->roundStart,
@@ -172,8 +161,8 @@ class SolrQueryFacetAppender
             : SolrDateMapper::roundEnd(
                 SolrDateMapper::mapDateTime($facet->base) .
                     SolrDateMapper::mapDateInterval(
-                        $upperBoundary,
-                        $upperBoundary->invert === 1 ? '-' : '+',
+                        $facet->to,
+                        $facet->to->invert === 1 ? '-' : '+',
                     ),
                 $facet->roundEnd,
             );

--- a/src/Service/Search/SolrQueryFilterAppender.php
+++ b/src/Service/Search/SolrQueryFilterAppender.php
@@ -157,12 +157,7 @@ class SolrQueryFilterAppender
     private function getRelativeDateRangeQuery(
         RelativeDateRangeFilter $filter,
     ): string {
-        $lowerBoundary = $filter->from;
-        if ($lowerBoundary === null && $filter->before !== null) {
-            $lowerBoundary = clone $filter->before;
-            $lowerBoundary->invert = 1; // before is always inverted
-        }
-        if ($lowerBoundary === null) {
+        if ($filter->from === null) {
             $from = SolrDateMapper::roundStart(
                 SolrDateMapper::mapDateTime($filter->base),
                 $filter->roundStart,
@@ -171,19 +166,13 @@ class SolrQueryFilterAppender
             $from = SolrDateMapper::roundStart(
                 SolrDateMapper::mapDateTime($filter->base) .
                     SolrDateMapper::mapDateInterval(
-                        $lowerBoundary,
-                        $lowerBoundary->invert === 1 ? '-' : '+',
+                        $filter->from,
+                        $filter->from->invert === 1 ? '-' : '+',
                     ),
                 $filter->roundStart,
             );
         }
-
-        $upperBoundary = $filter->to;
-        if ($upperBoundary === null && $filter->after !== null) {
-            $upperBoundary = clone $filter->after;
-            $upperBoundary->invert = 0; // after is always not inverted
-        }
-        if ($upperBoundary === null) {
+        if ($filter->to === null) {
             $to = SolrDateMapper::roundEnd(
                 SolrDateMapper::mapDateTime($filter->base),
                 $filter->roundEnd,
@@ -192,8 +181,8 @@ class SolrQueryFilterAppender
             $to = SolrDateMapper::roundEnd(
                 SolrDateMapper::mapDateTime($filter->base) .
                     SolrDateMapper::mapDateInterval(
-                        $upperBoundary,
-                        $upperBoundary->invert === 1 ? '-' : '+',
+                        $filter->to,
+                        $filter->to->invert === 1 ? '-' : '+',
                     ),
                 $filter->roundEnd,
             );


### PR DESCRIPTION
- Adds additional, optional fields `from` and `to` to the relative date range facet/filter. 
- Marks `before` and `after` as deprecated
- The fields `before`/`after` were implicitly directed toward the past/future, their `invert` property was ignored. With the fields `from`/`to`, the `invert` property is now properly processed