### PR TITLE
Feature/external resource factory kicker and scheduling

### DIFF
--- a/test/Service/Search/ExternalResourceFactoryTest.php
+++ b/test/Service/Search/ExternalResourceFactoryTest.php
@@ -121,7 +121,7 @@ class ExternalResourceFactoryTest extends TestCase
                     'isFullDay' => false,
                     'beginDate' => 1771286400,
                     'beginTime' => '14:30',
-                ]
+                ],
             ],
             $resource->data->getAssociativeArray('metadata.schedulingRaw'),
             'unexpected name',

--- a/test/Service/Search/ExternalResourceFactoryTest.php
+++ b/test/Service/Search/ExternalResourceFactoryTest.php
@@ -85,6 +85,49 @@ class ExternalResourceFactoryTest extends TestCase
         $this->factory->create($document, ResourceLanguage::of('en'));
     }
 
+    public function testWithKicker(): void
+    {
+        $document = $this->createDocument('https://www.sitepark.com');
+        $resource = $this->factory->create(
+            $document,
+            ResourceLanguage::of('en'),
+        );
+
+        $this->assertEquals(
+            'some kicker',
+            $resource->data->getString('base.kicker'),
+            'unexpected name',
+        );
+    }
+
+    public function testWithScheduling(): void
+    {
+        $document = $this->createDocument('https://www.sitepark.com');
+        $resource = $this->factory->create(
+            $document,
+            ResourceLanguage::of('en'),
+        );
+
+        $this->assertEquals(
+            [
+                [
+                    'type' => 'single',
+                    'isFullDay' => false,
+                    'beginDate' => 1770940800,
+                    'beginTime' => '17:30',
+                ],
+                [
+                    'type' => 'single',
+                    'isFullDay' => false,
+                    'beginDate' => 1771286400,
+                    'beginTime' => '14:30',
+                ]
+            ],
+            $resource->data->getAssociativeArray('metadata.schedulingRaw'),
+            'unexpected name',
+        );
+    }
+
     private function createDocument(string $url, string $title = ''): Document
     {
         $document = $this->createStub(Document::class);
@@ -94,6 +137,8 @@ class ExternalResourceFactoryTest extends TestCase
                 'url' => $url,
                 'title' => $title,
                 'description' => ['test'],
+                'sp_date_list' => ['2026-02-13T17:30:00Z', '2026-02-17T14:30:00Z'],
+                'sp_meta_string_kicker' => 'some kicker',
             ]);
         return $document;
     }


### PR DESCRIPTION
Adds features to the ExternalResourceFactory

- resource data field  `base.kicker` should be filled with the value of the solr field  `sp_meta_string_kicker`
- resource data filed `metadata.schedulingRaw` should be populated by resolving the dates from `sp_date_list`