### PR TITLE
feat: added new meta fields to IndexSchema2xDocument

### DIFF
--- a/src/Service/Indexer/IndexSchema2xDocument.php
+++ b/src/Service/Indexer/IndexSchema2xDocument.php
@@ -16,9 +16,18 @@ class IndexSchema2xDocument extends Document implements IndexDocument
     ];
 
     private const META_FIELDS = [
+        'metaLong',
+        'metaSingleLong',
+        'metaInt',
+        'metaSingleInt',
+        'metaFloat',
+        'metaSingleFloat',
         'metaString',
+        'metaSingleString',
         'metaText',
+        'metaSingleText',
         'metaBool',
+        'metaSingleBool',
     ];
 
     public ?string $sp_id = null;
@@ -136,10 +145,46 @@ class IndexSchema2xDocument extends Document implements IndexDocument
     public ?array $sp_citygov_product = null;
 
     public ?string $sp_citygov_function = null;
+
+    /**
+     * @var array<string,int|int[]>
+     */
+    private array $metaInt = [];
+
+    /**
+     * @var array<string,int>
+     */
+    private array $metaSingleInt = [];
+
+    /**
+     * @var array<string,int|int[]>
+     */
+    private array $metaLong = [];
+
+    /**
+     * @var array<string,int>
+     */
+    private array $metaSingleLong = [];
+
+    /**
+     * @var array<string,float|float[]>
+     */
+    private array $metaFloat = [];
+
+    /**
+     * @var array<string,float>
+     */
+    private array $metaSingleFloat = [];
+
     /**
      * @var array<string,string|string[]>
      */
     private array $metaString = [];
+
+    /**
+     * @var array<string,string>
+     */
+    private array $metaSingleString = [];
 
     /**
      * @var array<string,string|string[]>
@@ -147,9 +192,60 @@ class IndexSchema2xDocument extends Document implements IndexDocument
     private array $metaText = [];
 
     /**
+     * @var array<string,string>
+     */
+    private array $metaSingleText = [];
+
+    /**
      * @var array<string,bool>
      */
     private array $metaBool = [];
+
+    /**
+     * Same as $metaBool. The underlying solr schema is redundant here as
+     * `sp_meta_bool_*` and `sp_meta_singel_bool_*` have the same type definiton.
+     * @var array<string,bool>
+     */
+    private array $metaSingleBool = [];
+
+    /**
+     * @param int|int[] $value
+     */
+    public function setMetaInt(string $name, int|array $value): void
+    {
+        $this->metaInt['sp_meta_int_' . $name] = $value;
+    }
+
+    public function setMetaSingleInt(string $name, int $value): void
+    {
+        $this->metaSingleInt['sp_meta_single_int_' . $name] = $value;
+    }
+
+    /**
+     * @param int|int[] $value
+     */
+    public function setMetaLong(string $name, int|array $value): void
+    {
+        $this->metaLong['sp_meta_long_' . $name] = $value;
+    }
+
+    public function setMetaSingleLong(string $name, int $value): void
+    {
+        $this->metaSingleLong['sp_meta_single_long_' . $name] = $value;
+    }
+
+    /**
+     * @param float|float[] $value
+     */
+    public function setMetaFloat(string $name, float|array $value): void
+    {
+        $this->metaFloat['sp_meta_float_' . $name] = $value;
+    }
+
+    public function setMetaSingleFloat(string $name, float $value): void
+    {
+        $this->metaSingleFloat['sp_meta_single_float_' . $name] = $value;
+    }
 
     /**
      * @param string|string[] $value
@@ -157,6 +253,11 @@ class IndexSchema2xDocument extends Document implements IndexDocument
     public function setMetaString(string $name, string|array $value): void
     {
         $this->metaString['sp_meta_string_' . $name] = $value;
+    }
+
+    public function setMetaSingleString(string $name, string $value): void
+    {
+        $this->metaSingleString['sp_meta_single_string_' . $name] = $value;
     }
 
     /**
@@ -167,9 +268,19 @@ class IndexSchema2xDocument extends Document implements IndexDocument
         $this->metaText['sp_meta_text_' . $name] = $value;
     }
 
+    public function setMetaSingleText(string $name, string $value): void
+    {
+        $this->metaSingleText['sp_meta_single_text_' . $name] = $value;
+    }
+
     public function setMetaBool(string $name, bool $value): void
     {
         $this->metaBool['sp_meta_bool_' . $name] = $value;
+    }
+
+    public function setMetaSingleBool(string $name, bool $value): void
+    {
+        $this->metaSingleBool['sp_meta_single_bool_' . $name] = $value;
     }
 
     /**
@@ -186,9 +297,18 @@ class IndexSchema2xDocument extends Document implements IndexDocument
                     && !in_array($key, self::META_FIELDS, true),
                 ARRAY_FILTER_USE_BOTH,
             ),
-            ... $this->metaString,
-            ... $this->metaText,
-            ... $this->metaBool,
+            ...$this->metaLong,
+            ...$this->metaSingleLong,
+            ...$this->metaInt,
+            ...$this->metaSingleInt,
+            ...$this->metaFloat,
+            ...$this->metaSingleFloat,
+            ...$this->metaString,
+            ...$this->metaSingleString,
+            ...$this->metaText,
+            ...$this->metaSingleText,
+            ...$this->metaBool,
+            ...$this->metaSingleBool,
         ];
     }
 }

--- a/test/Service/Indexer/IndexSchema2xDocumentTest.php
+++ b/test/Service/Indexer/IndexSchema2xDocumentTest.php
@@ -23,6 +23,78 @@ class IndexSchema2xDocumentTest extends TestCase
         );
     }
 
+    public function testSetMetaInt(): void
+    {
+        $doc = new IndexSchema2xDocument();
+        $doc->setMetaInt('myname', 42);
+
+        $this->assertEquals(
+            ['sp_meta_int_myname' => 42],
+            $doc->getFields(),
+            'unexpected meta fields',
+        );
+    }
+
+    public function testSetMetaSingleInt(): void
+    {
+        $doc = new IndexSchema2xDocument();
+        $doc->setMetaSingleInt('myname', 42);
+
+        $this->assertEquals(
+            ['sp_meta_single_int_myname' => 42],
+            $doc->getFields(),
+            'unexpected meta fields',
+        );
+    }
+
+    public function testSetMetaLong(): void
+    {
+        $doc = new IndexSchema2xDocument();
+        $doc->setMetaLong('myname', 42);
+
+        $this->assertEquals(
+            ['sp_meta_long_myname' => 42],
+            $doc->getFields(),
+            'unexpected meta fields',
+        );
+    }
+
+    public function testSetMetaSingleLong(): void
+    {
+        $doc = new IndexSchema2xDocument();
+        $doc->setMetaSingleLong('myname', 42);
+
+        $this->assertEquals(
+            ['sp_meta_single_long_myname' => 42],
+            $doc->getFields(),
+            'unexpected meta fields',
+        );
+    }
+
+    public function testSetMetaFloat(): void
+    {
+        $doc = new IndexSchema2xDocument();
+        $doc->setMetaFloat('myname', 4.2);
+
+        $this->assertEquals(
+            ['sp_meta_float_myname' => 4.2],
+            $doc->getFields(),
+            'unexpected meta fields',
+        );
+    }
+
+    public function testSetMetaSingleFloat(): void
+    {
+        $doc = new IndexSchema2xDocument();
+        $doc->setMetaSingleFloat('myname', 4.2);
+
+        $this->assertEquals(
+            ['sp_meta_single_float_myname' => 4.2],
+            $doc->getFields(),
+            'unexpected meta fields',
+        );
+    }
+
     public function testSetMetaString(): void
     {
         $doc = new IndexSchema2xDocument();
@@ -30,6 +102,18 @@ class IndexSchema2xDocumentTest extends TestCase
 
         $this->assertEquals(
             ['sp_meta_string_myname' => 'myvalue'],
+            $doc->getFields(),
+            'unexpected meta fields',
+        );
+    }
+
+    public function testSetMetaSingleString(): void
+    {
+        $doc = new IndexSchema2xDocument();
+        $doc->setMetaSingleString('myname', 'myvalue');
+
+        $this->assertEquals(
+            ['sp_meta_single_string_myname' => 'myvalue'],
             $doc->getFields(),
             'unexpected meta fields',
         );
@@ -47,6 +131,18 @@ class IndexSchema2xDocumentTest extends TestCase
         );
     }
 
+    public function testSetMetaSingleText(): void
+    {
+        $doc = new IndexSchema2xDocument();
+        $doc->setMetaSingleText('myname', 'myvalue');
+
+        $this->assertEquals(
+            ['sp_meta_single_text_myname' => 'myvalue'],
+            $doc->getFields(),
+            'unexpected meta fields',
+        );
+    }
+
     public function testSetMetaBool(): void
     {
         $doc = new IndexSchema2xDocument();
@@ -54,6 +150,18 @@ class IndexSchema2xDocumentTest extends TestCase
 
         $this->assertEquals(
             ['sp_meta_bool_myname' => true],
+            $doc->getFields(),
+            'unexpected meta fields',
+        );
+    }
+
+    public function testSetMetaSingleBool(): void
+    {
+        $doc = new IndexSchema2xDocument();
+        $doc->setMetaSingleBool('myname', true);
+
+        $this->assertEquals(
+            ['sp_meta_single_bool_myname' => true],
             $doc->getFields(),
             'unexpected meta fields',
         );


### PR DESCRIPTION
Extended IndexSchema2xDocument to allow for more meta fields as defined in the [solr schema](https://github.com/sitepark/atoolo-e2e-test/blob/fdb9a8d4bbca6f132a55c241cb3d25b6024d2643/docker/solr/etc/solr/configsets/sitekit2x/conf/schema/default/2.1/schema.xml#L99)

So besides the already accessible fields  `sp_meta_string_`, `sp_meta_text_`, `sp_meta_bool_` I added setters for the remaining meta fields:
- `sp_meta_int_`
- `sp_meta_long_`
- `sp_meta_float_`

Also, every meta field has a single-valued equivalent, which I added as well:
- `sp_meta_single_string_`
- `sp_meta_single_text_`
- `sp_meta_single_bool_`
- `sp_meta_single_int_`
- `sp_meta_single_long_`
- `sp_meta_single_float_`