### PR TITLE
fix: update with locale

### DIFF
--- a/src/Service/Indexer/InternalResourceIndexer.php
+++ b/src/Service/Indexer/InternalResourceIndexer.php
@@ -191,6 +191,10 @@ class InternalResourceIndexer implements Indexer
 
         $this->skipCleanup = true;
 
+        $paths = array_map(function ($p) {
+            return $this->normalizePath($p);
+        }, $paths);
+
         $param = $this->loadIndexerParameter();
 
         $this->limitIncreaser?->increase();
@@ -533,21 +537,20 @@ class InternalResourceIndexer implements Indexer
      */
     private function toResourceLocation(string $path): ?ResourceLocation
     {
-        $normalizedPath = $this->normalizePath($path);
-        if (empty($normalizedPath)) {
+        if (empty($path)) {
             return null;
         }
 
-        $pos = strrpos($normalizedPath, '.php.translations');
+        $pos = strrpos($path, '.php.translations');
         if ($pos === false) {
-            return ResourceLocation::of($normalizedPath);
+            return ResourceLocation::of($path);
         }
 
-        $localeFilename = basename($normalizedPath);
+        $localeFilename = basename($path);
         $locale = basename($localeFilename, '.php');
 
         return ResourceLocation::of(
-            substr($normalizedPath, 0, $pos + 4),
+            substr($path, 0, $pos + 4),
             ResourceLanguage::of($locale),
         );
     }

--- a/test/Service/Indexer/InternalResourceIndexerTest.php
+++ b/test/Service/Indexer/InternalResourceIndexerTest.php
@@ -396,6 +396,20 @@ class InternalResourceIndexerTest extends TestCase
         ]);
     }
 
+    public function testUpdateOtherLangWithLocParam(): void
+    {
+        $this->finder
+            ->expects($this->once())
+            ->method('findPaths')
+            ->with([
+                '/a/b.php.translations/en_US.php',
+            ]);
+
+        $this->indexer->update([
+            '/a/b.php?loc=en_US',
+        ]);
+    }
+
     public function testUpdateWithParameter(): void
     {
         $this->finder->expects($this->once())

--- a/test/Service/Indexer/InternalResourceIndexerTest.php
+++ b/test/Service/Indexer/InternalResourceIndexerTest.php
@@ -410,11 +410,26 @@ class InternalResourceIndexerTest extends TestCase
         ]);
     }
 
+    public function testUpdateOtherLangWithOtherParam(): void
+    {
+        $this->finder
+            ->expects($this->once())
+            ->method('findPaths')
+            ->with([
+                '/a/b.php',
+            ]);
+
+        $this->indexer->update([
+            '/a/b.php?a=b',
+        ]);
+    }
+
     public function testUpdateWithParameter(): void
     {
         $this->finder->expects($this->once())
             ->method('findPaths')
-            ->with($this->equalTo(['?a=b']));
+            ->with($this->equalTo(['']))
+            ->willReturn(['']);
 
         $this->indexer->update([
             '?a=b',
@@ -523,23 +538,6 @@ class InternalResourceIndexerTest extends TestCase
         $this->indexerProgressHandler->expects($this->exactly(2))
             ->method('advance');
         $this->updater->expects($this->exactly(3))
-            ->method('addDocument');
-
-        $this->indexer->index();
-    }
-
-    public function testIndexWithoutLanguages(): void
-    {
-        $this->finder->method('findAll')
-            ->willReturn([
-                '?key=value',
-                '/a/b.php?key=value',
-                '/a/b.php?loc=',
-            ]);
-        $this->indexerFilter->method('accept')
-            ->willReturn(true);
-
-        $this->updater->expects($this->exactly(2))
             ->method('addDocument');
 
         $this->indexer->index();

--- a/test/Service/Indexer/SiteKit/DefaultSchema2xDocumentEnricherTest.php
+++ b/test/Service/Indexer/SiteKit/DefaultSchema2xDocumentEnricherTest.php
@@ -805,6 +805,21 @@ class DefaultSchema2xDocumentEnricherTest extends TestCase
         );
     }
 
+    public function testEnrichSearchTip(): void
+    {
+        $doc = $this->enrichWithData([
+            'objectType' => 'searchTip',
+            'name' => 'Sample Tip',
+            'base' => [
+                'title' => 'Abc',
+            ],
+        ]);
+        $this->assertNull(
+            $doc->sp_title,
+            'searchTip should not have sp_title',
+        );
+    }
+
     private function enrichWithResource(
         Resource $resource,
     ): IndexSchema2xDocument {
@@ -818,7 +833,7 @@ class DefaultSchema2xDocumentEnricherTest extends TestCase
     }
 
     /**
-     * @param array<string, array<string,mixed>> $data
+     * @param array<string, array<string,mixed>|string> $data
      */
     private function enrichWithData(
         array $data,


### PR DESCRIPTION
Update paths can contain a loc parameter that can be used to determine which language should be indexed. The parameter was chosen to be independent of how the language files are stored.

After refactoring, this parameter was no longer evaluated correctly.