### PR TITLE
feat: added parameter "minHitCount"

### DIFF
--- a/src/Dto/Search/Query/SuggestQuery.php
+++ b/src/Dto/Search/Query/SuggestQuery.php
@@ -25,5 +25,6 @@ class SuggestQuery
         public readonly array $filter = [],
         public readonly int $limit = 10,
         public readonly bool $archive = false,
+        public readonly int $minHitCount = 0,
     ) {}
 }

--- a/src/Service/Search/SolrSuggest.php
+++ b/src/Service/Search/SolrSuggest.php
@@ -69,6 +69,7 @@ class SolrSuggest implements Suggest
         $solrQuery->addParam("facet.prefix", $query->text);
         $solrQuery->addParam("facet.limit", $query->limit);
         $solrQuery->addParam("facet.field", $this->indexSuggestField);
+        $solrQuery->addParam("facet.mincount", $query->minHitCount);
 
         $solrQuery->setOmitHeader(false);
         $solrQuery->setStart(0);


### PR DESCRIPTION
Added parameter `minHitCount` to the suggest query to control the minimum number of hits a suggestion must have to be part of the result.