### PR TITLE
Add a 'clearDocuments' method to the SolrIndexUpdater class.

### DIFF
--- a/src/Service/Indexer/SolrIndexUpdater.php
+++ b/src/Service/Indexer/SolrIndexUpdater.php
@@ -33,6 +33,13 @@ class SolrIndexUpdater
         $this->documents[] = $document;
     }
 
+    public function clearDocuments(): void
+    {
+        foreach ($this->update->getCommands() as $command) {
+            $this->update->remove($command);
+        };
+    }
+
     public function update(): UpdateResult
     {
         $this->update->addDocuments($this->documents);

--- a/test/Service/Indexer/SolrIndexUpdaterTest.php
+++ b/test/Service/Indexer/SolrIndexUpdaterTest.php
@@ -6,6 +6,7 @@ namespace Atoolo\Search\Test\Service\Indexer;
 
 use Atoolo\Search\Service\Indexer\IndexSchema2xDocument;
 use Atoolo\Search\Service\Indexer\SolrIndexUpdater;
+use Solarium\QueryType\Update\Query\Command\Add as AddCommand;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -48,5 +49,22 @@ class SolrIndexUpdaterTest extends TestCase
             ->method('addDocuments')
             ->with([$doc]);
         $this->updater->update();
+    }
+
+    public function testClearDocuments(): void
+    {
+        $doc = $this->updater->createDocument();
+        $this->updater->addDocument($doc);
+        $addCommand = new AddCommand();
+        $addCommand->addDocument($doc);
+        $this->updateQuery->method('getCommands')->willReturn(
+            [$addCommand],
+        );
+
+        $this->updateQuery->expects($this->once())
+            ->method('remove')
+            ->with($addCommand);
+
+        $this->updater->clearDocuments();
     }
 }


### PR DESCRIPTION
If the updater is to be reused for multiple operations, the list of documents must be cleared between 'update' calls. The 'clearDocuments' function now serves this purpose.